### PR TITLE
feat: add testing-patterns and typescript-migration skills

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,12 +28,12 @@ foundation-skills/
 
 ## Key Directories
 
-- `skills/` — Contains 34 skill directories, each with a `SKILL.md` file defining the skill's instructions
+- `skills/` — Contains 36 skill directories, each with a `SKILL.md` file defining the skill's instructions
 - `docs/` — Contains documentation files: one per skill plus general guides (healthcare parsers, installation, etc.)
 
 ## Skill Categories
 
-1. **Development skills:** coding-standards, backend-patterns, react-best-practices, vue-best-practices, frontend-design, web-design-guidelines, create-design-system-rules, mcp-builder, playwright-skill, postgres, security-review, tdd, git-guardrails, write-a-skill
+1. **Development skills:** coding-standards, backend-patterns, react-best-practices, vue-best-practices, frontend-design, web-design-guidelines, create-design-system-rules, mcp-builder, playwright-skill, postgres, security-review, tdd, testing-patterns, typescript-migration, git-guardrails, write-a-skill
 2. **Healthcare & legacy:** hpk-parser, hl7-pam-parser, hexagone-frontend, hexagone-swdoc, uniface-procscript
 3. **Issue/review management:** gitlab-code-review, gitlab-issue, github-issues, triage-issue
 4. **Document processing:** docx, pdf, pptx, xlsx, article-extractor

--- a/README.md
+++ b/README.md
@@ -74,6 +74,8 @@ npx skills add Dedalus-ERP-PAS/foundation-skills --skill backend-patterns --skil
 | [Hexagone Web Services](docs/hexagone-swdoc.md)           | Documentation des web services Hexagone depuis le dépôt swdoc GitLab                      |
 | [Hexagone Frontend](docs/hexagone-frontend.md)            | Documentation des composants frontend Hexagone (@his/hexa-components)                     |
 | [TDD](docs/tdd.md)                                        | Développement piloté par les tests avec boucle red-green-refactor                         |
+| [Testing patterns](docs/testing-patterns.md)               | Patterns de test : unitaire, intégration, E2E, mocking et organisation                    |
+| [TypeScript migration](docs/typescript-migration.md)       | Guide de migration incrémentale JavaScript vers TypeScript                                |
 | [Triage issue](docs/triage-issue.md)                      | Investigation de bugs et création automatique d'issues GitLab/GitHub                      |
 | [Ubiquitous language](docs/ubiquitous-language.md)        | Extraction de glossaire DDD adapté au domaine santé                                       |
 | [Git guardrails](docs/git-guardrails.md)                  | Hooks de sécurité pour bloquer les commandes git dangereuses                              |
@@ -154,6 +156,8 @@ Le développeur installe les skills via la commande `npx skills add`. Les fichie
 | **react-best-practices**       | Best practices React/Next.js : architecture, performance, shadcn/ui, React 19+                     | [react-best-practices.md](docs/react-best-practices.md)             |
 | **security-review**            | Audit de sécurité : secrets, validation inputs, authentification, OWASP Top 10                     | [security-review.md](docs/security-review.md)                       |
 | **vue-best-practices**         | Best practices Vue.js 3/Nuxt : Composition API, réactivité, Tailwind CSS, PrimeVue                 | [vue-best-practices.md](docs/vue-best-practices.md)                 |
+| **testing-patterns**           | Patterns de test complets : unitaire, intégration, E2E, mocking, anti-patterns                     | [testing-patterns.md](docs/testing-patterns.md)                     |
+| **typescript-migration**       | Migration incrémentale JS → TypeScript : tsconfig, typage, élimination de `any`                    | [typescript-migration.md](docs/typescript-migration.md)             |
 | **web-design-guidelines**      | Audit UI/UX : conformité Web Interface Guidelines, accessibilité                                   | [web-design-guidelines.md](docs/web-design-guidelines.md)           |
 | **hexagone-swdoc**             | Documentation des web services Hexagone : endpoints, formats, contrats de service                  | [hexagone-swdoc.md](docs/hexagone-swdoc.md)                         |
 | **hexagone-frontend**          | Documentation des composants frontend Hexagone (@his/hexa-components) : props, events, patterns    | [hexagone-frontend.md](docs/hexagone-frontend.md)                   |

--- a/docs/README.md
+++ b/docs/README.md
@@ -33,8 +33,10 @@ Index de toute la documentation disponible pour les Foundation Skills.
 | --------------------------------------- | ------------------------------------------------ |
 | [security-review](security-review.md)   | Audit de sécurité et OWASP Top 10                |
 | [coding-standards](coding-standards.md) | Standards de code                                |
-| [tdd](tdd.md)                           | Développement piloté par les tests (TDD)         |
-| [git-guardrails](git-guardrails.md)     | Garde-fous Git pour des commits propres          |
+| [tdd](tdd.md)                                     | Développement piloté par les tests (TDD)         |
+| [testing-patterns](testing-patterns.md)           | Patterns de test : unitaire, intégration, E2E    |
+| [typescript-migration](typescript-migration.md)   | Migration incrémentale JS → TypeScript           |
+| [git-guardrails](git-guardrails.md)               | Garde-fous Git pour des commits propres          |
 
 ### Automatisation & Tests
 

--- a/docs/testing-patterns.md
+++ b/docs/testing-patterns.md
@@ -1,0 +1,102 @@
+# testing-patterns
+
+Patterns et stratégies de test complets pour les projets JavaScript/TypeScript : tests unitaires, d'intégration, E2E, mocking, organisation et anti-patterns.
+
+## Quand utiliser ce skill
+
+Utilisez ce skill pour :
+- Écrire des tests pour du code existant ou nouveau
+- Établir une stratégie de test pour un projet
+- Améliorer la couverture ou la fiabilité des tests
+- Corriger des tests instables (flaky)
+- Choisir entre mock, stub et spy
+- Décider quand faire du test unitaire vs intégration vs E2E
+
+## Complémentarité avec le skill `tdd`
+
+| Skill | Focus |
+|-------|-------|
+| **tdd** | Le *workflow* : boucle red-green-refactor, vertical slices |
+| **testing-patterns** | Les *patterns* : comment écrire de bons tests, stratégie de mocking, organisation |
+
+Les deux skills se complètent. Utilisez `tdd` quand vous développez en TDD, et `testing-patterns` pour les patterns concrets.
+
+## Pyramide des tests
+
+```
+        /  E2E  \          Peu, lents, haute confiance
+       /----------\
+      / Intégration \      Nombre modéré, vitesse moyenne
+     /----------------\
+    /     Unitaires    \   Nombreux, rapides, ciblés
+   /____________________\
+```
+
+**Règle générale** : ~70% unitaires, ~20% intégration, ~10% E2E. Les codebases legacy bénéficient souvent de plus de tests d'intégration au départ.
+
+## Contenu du skill
+
+### Tests unitaires
+- Pattern AAA (Arrange, Act, Assert)
+- Nommage descriptif des tests (spécifications)
+- Tests paramétrés (table-driven)
+- Tests de cas d'erreur
+- Tests de code asynchrone
+
+### Tests d'intégration
+- Tests base de données (avec vraie DB, pas de mock)
+- Tests d'API HTTP (supertest)
+- Tests de pipelines de messages (HPK, HL7)
+
+### Tests E2E
+- Page Object Pattern
+- Convention `data-testid`
+- Tests de régression visuelle
+
+### Stratégies de mocking
+- Quand mocker vs ne pas mocker
+- Mock vs Stub vs Spy
+- MSW pour le mocking HTTP
+- Mocking du temps
+
+### Organisation des tests
+- Colocation (tests à côté du code source)
+- Factories pour les données de test
+- Utilitaires partagés
+
+### Anti-patterns
+- Tester les détails d'implémentation
+- Mocking excessif
+- Tests instables (flaky) : causes et solutions
+- Abus de snapshots
+
+## Exemples d'utilisation
+
+```
+@workspace avec testing-patterns, écris les tests pour ce service patient
+@workspace avec testing-patterns, cette suite de tests est flaky, aide-moi à la stabiliser
+@workspace avec testing-patterns, établis une stratégie de test pour ce projet
+@workspace avec testing-patterns et tdd, implémente cette feature en TDD
+```
+
+## Frameworks supportés
+
+| Framework | Usage |
+|-----------|-------|
+| **Vitest** | Unitaires + intégration (projets Vite) |
+| **Jest** | Unitaires + intégration (legacy, CRA) |
+| **Playwright** | E2E, régression visuelle |
+| **Cypress** | E2E, tests de composants |
+| **Testing Library** | Tests DOM (React, Vue) |
+| **MSW** | Mocking HTTP |
+
+## Démarrage rapide
+
+```bash
+npx skills add Dedalus-ERP-PAS/foundation-skills --skill testing-patterns -g -y
+```
+
+## Ressources
+
+- [SKILL.md complet](../skills/testing-patterns/SKILL.md) — Tous les patterns avec exemples de code
+- [Skill TDD](../skills/tdd/SKILL.md) — Workflow red-green-refactor

--- a/docs/typescript-migration.md
+++ b/docs/typescript-migration.md
@@ -1,0 +1,104 @@
+# typescript-migration
+
+Guide de migration incrémentale de codebases JavaScript vers TypeScript. Stratégie fichier par fichier, configuration tsconfig, typage du code legacy et élimination progressive de `any`.
+
+## Quand utiliser ce skill
+
+Utilisez ce skill pour :
+- Convertir un projet JavaScript (ou une partie) en TypeScript
+- Ajouter TypeScript à un projet JS existant
+- Typer du code legacy progressivement
+- Réduire l'utilisation de `any` dans une codebase
+- Configurer tsconfig pour un projet mixte JS/TS
+
+## Principe fondamental
+
+**Ne jamais tout réécrire d'un coup.** Migrer fichier par fichier, en partant des feuilles de l'arbre de dépendances. Chaque état intermédiaire doit être une codebase fonctionnelle.
+
+## Les 5 phases de migration
+
+| Phase | Action | Risque |
+|-------|--------|--------|
+| **1. Setup** | tsconfig + tooling, zéro changement de code | Nul |
+| **2. Rename** | .js → .ts pour les fichiers feuilles, corriger les erreurs | Faible |
+| **3. Type boundaries** | Typer les APIs publiques et interfaces partagées | Faible |
+| **4. Tighten** | Activer les checks stricts un par un | Moyen |
+| **5. Strict mode** | `strict: true`, supprimer `allowJs` | Moyen |
+
+## Contenu du skill
+
+### Phase 1 — Setup
+- Installation de TypeScript et `@types/*`
+- Configuration `tsconfig.json` permissive pour migration
+- Adaptation des outils de build (Vite, Webpack, Next.js)
+
+### Phase 2 — Rename (leaf-first)
+- Identification de l'ordre de migration (feuilles d'abord)
+- Stratégie de typage par fichier
+- Ajout de types explicites aux exports
+
+### Phase 3 — Type boundaries
+- Création de fichiers de types partagés (`types/`)
+- Typage des réponses API (`ApiResponse<T>`, `PaginatedResponse<T>`)
+- Typage des payloads de messages (HPK, HL7) avec discriminated unions
+
+### Phase 4 — Tighten
+- Activation progressive : `strictNullChecks` → `noImplicitAny` → `noImplicitReturns` → `strict`
+- Patterns pour gérer les erreurs `strictNullChecks`
+- Stratégies pour éliminer `any` : `unknown`, type guards, Zod
+
+### Phase 5 — Strict mode
+- Activation de `strict: true`
+- Suppression de `allowJs`
+- Vérification de la couverture de types
+
+## Patterns pour le code legacy
+
+Le skill couvre des patterns spécifiques au code legacy :
+- Typage de code avec callbacks → async/await
+- Typage d'objets dynamiques (`Record`, index signatures)
+- Déclarations de types pour les librairies non typées (`.d.ts`)
+- Typage de middleware Express
+- Discriminated unions pour les messages healthcare
+
+## Checklist de migration
+
+Le skill inclut 3 checklists :
+1. **Avant de commencer** — alignement équipe, tooling, tsconfig
+2. **Par fichier** — types exports, interfaces, pas de `any`, tests passent
+3. **Avant strict mode** — tous fichiers .ts, nullChecks OK, `any` éliminé
+
+## Pièges courants
+
+| Piège | Conséquence | Solution |
+|-------|-------------|----------|
+| `as any` partout | TypeScript inutile | `unknown` + type guards |
+| Réécrire le code pendant la migration | Bugs, blocage | Migrer les types, refactorer après |
+| Démarrer en strict | Trop d'erreurs, abandon | Démarrer permissif, durcir progressivement |
+| PR géantes (50 fichiers) | Impossible à reviewer | 1 fichier ou module par PR |
+
+## Exemples d'utilisation
+
+```
+@workspace avec typescript-migration, configure TypeScript pour ce projet JS
+@workspace avec typescript-migration, migre ce fichier en TypeScript
+@workspace avec typescript-migration, élimine les `any` de ce module
+@workspace avec typescript-migration, active strictNullChecks et corrige les erreurs
+```
+
+## Démarrage rapide
+
+```bash
+npx skills add Dedalus-ERP-PAS/foundation-skills --skill typescript-migration -g -y
+```
+
+## Skills complémentaires
+
+- **coding-standards** — Conventions TypeScript/JavaScript
+- **testing-patterns** — Patterns de test (vérifier que les tests passent après migration)
+- **tdd** — Développement piloté par les tests
+
+## Ressources
+
+- [SKILL.md complet](../skills/typescript-migration/SKILL.md) — Guide détaillé avec exemples de code
+- [TypeScript Handbook — Migrating from JavaScript](https://www.typescriptlang.org/docs/handbook/migrating-from-javascript.html)

--- a/skills/testing-patterns/SKILL.md
+++ b/skills/testing-patterns/SKILL.md
@@ -1,0 +1,499 @@
+---
+name: testing-patterns
+description: Comprehensive testing patterns and strategies for JavaScript/TypeScript projects. Covers unit, integration, and E2E testing, mocking strategies, test organization, and common anti-patterns. Use when the user wants to write tests, improve test coverage, establish a testing strategy, or fix flaky tests.
+version: 1.0.0
+license: MIT
+metadata:
+  author: Foundation Skills
+---
+
+# Testing Patterns & Strategies
+
+Comprehensive guide to testing JavaScript/TypeScript applications. Complements the `tdd` skill (which focuses on workflow) by providing concrete patterns, strategies, and anti-patterns.
+
+## When to Use This Skill
+
+Activate when the user:
+- Wants to write tests for existing or new code
+- Needs to establish a testing strategy for a project
+- Wants to improve test coverage or reliability
+- Has flaky or brittle tests
+- Asks about mocking, stubbing, or test doubles
+- Needs guidance on unit vs integration vs E2E tests
+
+## Testing Pyramid
+
+```
+        /  E2E  \          Few, slow, high confidence
+       /----------\
+      / Integration \      Moderate count, medium speed
+     /----------------\
+    /      Unit        \   Many, fast, focused
+   /____________________\
+```
+
+**Rule of thumb:** ~70% unit, ~20% integration, ~10% E2E. Adjust per project — legacy codebases often benefit from more integration tests initially.
+
+## 1. Unit Testing Patterns
+
+### Test Structure: AAA (Arrange, Act, Assert)
+
+```typescript
+describe('calculateDiscount', () => {
+  it('should apply 10% discount for orders above 100€', () => {
+    // Arrange
+    const order = { total: 150, items: ['item1', 'item2'] }
+
+    // Act
+    const result = calculateDiscount(order)
+
+    // Assert
+    expect(result).toBe(135)
+  })
+})
+```
+
+### Naming Convention
+
+Use descriptive names that read as specifications:
+
+```typescript
+// GOOD — describes behavior
+it('should return 401 when token is expired')
+it('should retry 3 times before failing')
+it('should trim whitespace from patient name')
+
+// BAD — describes implementation
+it('should call validateToken')
+it('should set retryCount to 3')
+it('should use .trim()')
+```
+
+### Parameterized Tests (Table-Driven)
+
+```typescript
+describe('parseHL7Date', () => {
+  it.each([
+    ['20260315', new Date(2026, 2, 15)],
+    ['20260315120000', new Date(2026, 2, 15, 12, 0, 0)],
+    ['', null],
+    ['invalid', null],
+  ])('should parse "%s" to %s', (input, expected) => {
+    expect(parseHL7Date(input)).toEqual(expected)
+  })
+})
+```
+
+### Testing Error Cases
+
+Always test the unhappy path:
+
+```typescript
+describe('PatientService.findById', () => {
+  it('should throw NotFoundError for unknown patient ID', async () => {
+    await expect(service.findById('UNKNOWN'))
+      .rejects.toThrow(NotFoundError)
+  })
+
+  it('should throw ValidationError for empty ID', async () => {
+    await expect(service.findById(''))
+      .rejects.toThrow(ValidationError)
+  })
+})
+```
+
+### Testing Async Code
+
+```typescript
+// Promises
+it('should resolve with patient data', async () => {
+  const patient = await fetchPatient('PAT123')
+  expect(patient.name).toBe('DUPONT')
+})
+
+// Event emitters
+it('should emit "transfer" event on unit change', (done) => {
+  emitter.on('transfer', (data) => {
+    expect(data.unit).toBe('CARDIO')
+    done()
+  })
+  service.transferPatient('PAT123', 'CARDIO')
+})
+```
+
+## 2. Integration Testing Patterns
+
+Integration tests verify that components work together correctly.
+
+### Database Integration Tests
+
+```typescript
+describe('PatientRepository', () => {
+  let db: TestDatabase
+
+  beforeAll(async () => {
+    db = await TestDatabase.create()  // Real DB, not mock
+    await db.migrate()
+  })
+
+  afterEach(async () => {
+    await db.truncate()  // Clean between tests
+  })
+
+  afterAll(async () => {
+    await db.destroy()
+  })
+
+  it('should persist and retrieve a patient', async () => {
+    const repo = new PatientRepository(db.connection)
+
+    await repo.create({
+      id: 'PAT123',
+      name: 'DUPONT',
+      birthDate: '1975-03-15',
+    })
+
+    const found = await repo.findById('PAT123')
+    expect(found).toMatchObject({
+      id: 'PAT123',
+      name: 'DUPONT',
+    })
+  })
+})
+```
+
+### API Integration Tests
+
+```typescript
+describe('POST /api/patients', () => {
+  it('should create a patient and return 201', async () => {
+    const response = await request(app)
+      .post('/api/patients')
+      .send({ name: 'DUPONT', birthDate: '1975-03-15' })
+      .set('Authorization', `Bearer ${validToken}`)
+
+    expect(response.status).toBe(201)
+    expect(response.body.data.id).toBeDefined()
+  })
+
+  it('should return 400 for missing required fields', async () => {
+    const response = await request(app)
+      .post('/api/patients')
+      .send({})  // Missing name
+      .set('Authorization', `Bearer ${validToken}`)
+
+    expect(response.status).toBe(400)
+    expect(response.body.errors).toContainEqual(
+      expect.objectContaining({ field: 'name' })
+    )
+  })
+
+  it('should return 401 without authentication', async () => {
+    const response = await request(app)
+      .post('/api/patients')
+      .send({ name: 'DUPONT' })
+
+    expect(response.status).toBe(401)
+  })
+})
+```
+
+### Message Processing Integration Tests
+
+Particularly relevant for healthcare message processing (HPK, HL7):
+
+```typescript
+describe('HPK Message Pipeline', () => {
+  it('should parse, validate, and transform an ID|M1 message', async () => {
+    const rawMessage = 'ID|M1|C|HEXAGONE|20260122120000|USER001|PAT123|DUPONT|JEAN|19750315|M'
+
+    const result = await pipeline.process(rawMessage)
+
+    expect(result.type).toBe('ID')
+    expect(result.code).toBe('M1')
+    expect(result.patient.name).toBe('DUPONT')
+    expect(result.valid).toBe(true)
+  })
+})
+```
+
+## 3. E2E Testing Patterns
+
+E2E tests validate complete user workflows through the real application.
+
+### Page Object Pattern
+
+```typescript
+class PatientListPage {
+  constructor(private page: Page) {}
+
+  async goto() {
+    await this.page.goto('/patients')
+  }
+
+  async search(query: string) {
+    await this.page.fill('[data-testid="search-input"]', query)
+    await this.page.click('[data-testid="search-button"]')
+  }
+
+  async getResults() {
+    return this.page.locator('[data-testid="patient-row"]').allTextContents()
+  }
+
+  async clickPatient(name: string) {
+    await this.page.click(`text=${name}`)
+  }
+}
+
+// Usage in test
+test('should find patient by name', async ({ page }) => {
+  const patientList = new PatientListPage(page)
+  await patientList.goto()
+  await patientList.search('DUPONT')
+
+  const results = await patientList.getResults()
+  expect(results).toContain('DUPONT JEAN')
+})
+```
+
+### Data-testid Convention
+
+Use `data-testid` attributes for test selectors, never CSS classes or element structure:
+
+```typescript
+// GOOD — stable selector
+await page.click('[data-testid="submit-admission"]')
+
+// BAD — brittle, breaks on style/structure changes
+await page.click('.btn.btn-primary.submit')
+await page.click('form > div:nth-child(3) > button')
+```
+
+### Visual Regression Testing
+
+```typescript
+test('patient dashboard matches snapshot', async ({ page }) => {
+  await page.goto('/dashboard')
+  await page.waitForLoadState('networkidle')
+  await expect(page).toHaveScreenshot('dashboard.png', {
+    maxDiffPixelRatio: 0.01,
+  })
+})
+```
+
+## 4. Mocking Strategies
+
+### When to Mock
+
+| Mock | Don't Mock |
+|------|------------|
+| External HTTP APIs | Your own database (use real test DB) |
+| Time/Date (for determinism) | Internal collaborators between modules |
+| File system (when impractical) | Simple utility functions |
+| Third-party services (payment, email) | Data transformations |
+| Environment-specific features | Business logic |
+
+### Mock vs Stub vs Spy
+
+```typescript
+// STUB — returns a fixed value
+const getPatient = vi.fn().mockResolvedValue({ id: 'PAT123', name: 'DUPONT' })
+
+// SPY — observes calls without changing behavior
+const logSpy = vi.spyOn(logger, 'info')
+await service.admitPatient(data)
+expect(logSpy).toHaveBeenCalledWith('Patient admitted', { id: 'PAT123' })
+
+// MOCK — replaces the entire module
+vi.mock('./emailService', () => ({
+  sendAdmissionNotification: vi.fn().mockResolvedValue(true),
+}))
+```
+
+### MSW for HTTP Mocking
+
+Prefer MSW (Mock Service Worker) over manual fetch mocking:
+
+```typescript
+import { http, HttpResponse } from 'msw'
+import { setupServer } from 'msw/node'
+
+const server = setupServer(
+  http.get('/api/patients/:id', ({ params }) => {
+    return HttpResponse.json({
+      id: params.id,
+      name: 'DUPONT',
+      birthDate: '1975-03-15',
+    })
+  })
+)
+
+beforeAll(() => server.listen())
+afterEach(() => server.resetHandlers())
+afterAll(() => server.close())
+```
+
+### Time Mocking
+
+```typescript
+describe('token expiration', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('should reject expired tokens', () => {
+    const token = createToken({ expiresIn: '1h' })
+
+    vi.advanceTimersByTime(2 * 60 * 60 * 1000)  // 2 hours later
+
+    expect(() => validateToken(token)).toThrow('Token expired')
+  })
+})
+```
+
+## 5. Test Organization
+
+### File Structure — Colocation
+
+```
+src/
+├── patients/
+│   ├── PatientService.ts
+│   ├── PatientService.test.ts      # Unit tests next to source
+│   ├── PatientRepository.ts
+│   └── PatientRepository.test.ts
+├── __tests__/
+│   └── integration/
+│       ├── patient-admission.test.ts    # Integration tests
+│       └── hl7-message-flow.test.ts
+└── e2e/
+    ├── patient-workflow.spec.ts    # E2E tests
+    └── pages/
+        └── PatientListPage.ts     # Page objects
+```
+
+### Test Utilities — Factories
+
+Avoid copy-pasting test data. Use factories:
+
+```typescript
+// test/factories/patient.ts
+export function buildPatient(overrides: Partial<Patient> = {}): Patient {
+  return {
+    id: `PAT${Math.random().toString(36).slice(2, 8)}`,
+    name: 'DUPONT',
+    firstName: 'JEAN',
+    birthDate: '1975-03-15',
+    sex: 'M',
+    ...overrides,
+  }
+}
+
+// Usage
+it('should flag underage patients', () => {
+  const minor = buildPatient({ birthDate: '2015-06-01' })
+  expect(isMinor(minor)).toBe(true)
+})
+```
+
+## 6. Common Anti-Patterns
+
+### Testing Implementation Details
+
+```typescript
+// BAD — tests internal state
+it('should set isLoading to true', () => {
+  component.fetchData()
+  expect(component.state.isLoading).toBe(true)
+})
+
+// GOOD — tests observable behavior
+it('should show loading spinner while fetching', async () => {
+  render(<PatientList />)
+  expect(screen.getByTestId('spinner')).toBeVisible()
+  await waitForElementToBeRemoved(screen.queryByTestId('spinner'))
+})
+```
+
+### Excessive Mocking
+
+```typescript
+// BAD — mocking everything, testing nothing real
+it('should create patient', async () => {
+  vi.mock('./db')
+  vi.mock('./validator')
+  vi.mock('./logger')
+  // ... what are you even testing?
+})
+
+// GOOD — use real implementations, mock only boundaries
+it('should create patient in database', async () => {
+  const repo = new PatientRepository(testDb)
+  const service = new PatientService(repo)  // Real repo, real DB
+
+  const patient = await service.create({ name: 'DUPONT' })
+  expect(patient.id).toBeDefined()
+})
+```
+
+### Flaky Test Patterns
+
+Common causes and fixes:
+
+| Cause | Fix |
+|-------|-----|
+| Shared mutable state | Use `beforeEach` to reset state |
+| Time-dependent tests | Use `vi.useFakeTimers()` |
+| Race conditions in async tests | Use `waitFor` / `findBy` instead of `getBy` |
+| Order-dependent tests | Each test must be independent |
+| Network calls in unit tests | Mock HTTP with MSW |
+| Hardcoded ports | Use dynamic port assignment |
+
+### Snapshot Overuse
+
+```typescript
+// BAD — meaningless snapshot of entire component
+it('should render', () => {
+  const { container } = render(<PatientCard patient={patient} />)
+  expect(container).toMatchSnapshot()  // 200 lines of HTML nobody reads
+})
+
+// GOOD — targeted assertions
+it('should display patient name and birthdate', () => {
+  render(<PatientCard patient={patient} />)
+  expect(screen.getByText('DUPONT JEAN')).toBeVisible()
+  expect(screen.getByText('15/03/1975')).toBeVisible()
+})
+```
+
+## 7. Testing Checklist
+
+Before submitting a PR, verify:
+
+```
+[ ] New feature has tests covering happy path and error cases
+[ ] Tests are independent — can run in any order
+[ ] No flaky tests introduced (run suite 3x to verify)
+[ ] Test names describe behavior, not implementation
+[ ] Mocks are limited to external boundaries
+[ ] No hardcoded test data — using factories
+[ ] Test utilities are shared, not duplicated
+[ ] Integration tests clean up after themselves
+[ ] E2E tests use data-testid selectors
+[ ] Coverage hasn't decreased
+```
+
+## Framework Quick Reference
+
+| Framework | Best For | Command |
+|-----------|----------|---------|
+| **Vitest** | Unit + integration (Vite projects) | `vitest run` |
+| **Jest** | Unit + integration (legacy, CRA) | `jest --coverage` |
+| **Playwright** | E2E, visual regression | `playwright test` |
+| **Cypress** | E2E, component testing | `cypress run` |
+| **Testing Library** | DOM testing (React, Vue) | Used with Vitest/Jest |
+| **MSW** | HTTP mocking | Used with any runner |

--- a/skills/typescript-migration/SKILL.md
+++ b/skills/typescript-migration/SKILL.md
@@ -1,0 +1,458 @@
+---
+name: typescript-migration
+description: Guide for incrementally migrating JavaScript codebases to TypeScript. Covers tsconfig setup, file-by-file migration, typing strategies for legacy code, handling `any`, and common pitfalls. Use when the user wants to convert JS to TS, add types to existing code, set up TypeScript in a JS project, or improve type safety.
+version: 1.0.0
+license: MIT
+metadata:
+  author: Foundation Skills
+---
+
+# TypeScript Migration Guide
+
+Incremental strategy for migrating JavaScript codebases to TypeScript. Designed for legacy projects that need progressive, non-disruptive migration.
+
+## When to Use This Skill
+
+Activate when the user:
+- Wants to convert a JS project (or parts of it) to TypeScript
+- Needs to add TypeScript to an existing JavaScript project
+- Asks about typing legacy code or reducing `any` usage
+- Wants to improve type safety incrementally
+- Is setting up tsconfig for a mixed JS/TS codebase
+
+## Core Principle: Incremental Migration
+
+**Never rewrite everything at once.** Migrate file by file, starting from the leaves of the dependency tree. Every intermediate state must be a working codebase.
+
+```
+Phase 1: Setup          → tsconfig + tooling, zero code changes
+Phase 2: Rename         → .js → .ts for leaf files, fix type errors
+Phase 3: Type boundaries → Add types to public APIs and shared interfaces
+Phase 4: Deepen         → Enable stricter checks, eliminate `any`
+Phase 5: Strict mode    → Full strict TypeScript
+```
+
+## Phase 1: Project Setup
+
+### 1.1 Install TypeScript
+
+```bash
+npm install --save-dev typescript @types/node
+```
+
+For framework-specific types:
+
+```bash
+# React
+npm install --save-dev @types/react @types/react-dom
+
+# Express
+npm install --save-dev @types/express
+
+# Vue (types included in vue package)
+# No extra install needed
+```
+
+### 1.2 Create tsconfig.json
+
+Start permissive, tighten later:
+
+```json
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+
+    "allowJs": true,
+    "checkJs": false,
+
+    "strict": false,
+    "noImplicitAny": false,
+    "strictNullChecks": false,
+
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist", "**/*.test.*"]
+}
+```
+
+**Key settings for migration:**
+- `allowJs: true` — allows mixed JS/TS
+- `checkJs: false` — don't type-check JS files yet
+- `strict: false` — start permissive
+- `noImplicitAny: false` — allow implicit `any` initially
+
+### 1.3 Update Build Tools
+
+Most modern tools support TS out of the box:
+
+```bash
+# Vite — zero config needed
+# Next.js — zero config, just rename files
+# Webpack — add ts-loader or use babel
+npm install --save-dev ts-loader
+```
+
+## Phase 2: Rename and Fix (Leaf-First)
+
+### 2.1 Identify Migration Order
+
+Start from files with NO internal imports (leaf nodes), then work up:
+
+```
+Level 0 (first):  utils/formatDate.js     → no imports from src/
+Level 0 (first):  constants/index.js       → no imports from src/
+Level 1:          services/dateService.js   → imports from utils/
+Level 2:          api/patientApi.js         → imports from services/
+Level 3 (last):   pages/PatientList.jsx     → imports from everything
+```
+
+### 2.2 Rename One File at a Time
+
+```bash
+# Rename
+mv src/utils/formatDate.js src/utils/formatDate.ts
+
+# Fix type errors
+# Run build/IDE to see errors
+npx tsc --noEmit
+```
+
+### 2.3 Typing Strategy Per File
+
+For each renamed file:
+
+1. **Add explicit return types** to exported functions
+2. **Add parameter types** to exported functions
+3. **Add interface/type for complex objects**
+4. **Use `unknown` instead of `any`** where possible
+5. **Keep internal functions loosely typed** initially — tighten later
+
+```typescript
+// BEFORE (JavaScript)
+export function formatPatientName(patient) {
+  return `${patient.lastName} ${patient.firstName}`
+}
+
+// AFTER (TypeScript — Phase 2)
+interface Patient {
+  lastName: string
+  firstName: string
+}
+
+export function formatPatientName(patient: Patient): string {
+  return `${patient.lastName} ${patient.firstName}`
+}
+```
+
+## Phase 3: Type Boundaries
+
+Focus on typing the **public API surface** — exports, function signatures, shared types.
+
+### 3.1 Create Shared Type Files
+
+```typescript
+// src/types/patient.ts
+export interface Patient {
+  id: string
+  lastName: string
+  firstName: string
+  birthDate: string  // ISO 8601
+  sex: 'M' | 'F' | 'U'
+  ipp?: string       // Internal Patient ID (optional)
+}
+
+export interface PatientSearchParams {
+  query?: string
+  unit?: string
+  page?: number
+  limit?: number
+}
+
+export type PatientCreateInput = Omit<Patient, 'id'>
+```
+
+### 3.2 Type API Responses
+
+```typescript
+// src/types/api.ts
+export interface ApiResponse<T> {
+  success: boolean
+  data: T
+  error?: ApiError
+}
+
+export interface ApiError {
+  code: string
+  message: string
+  details?: Record<string, string[]>
+}
+
+export interface PaginatedResponse<T> extends ApiResponse<T[]> {
+  pagination: {
+    page: number
+    limit: number
+    total: number
+    totalPages: number
+  }
+}
+```
+
+### 3.3 Type Event/Message Payloads
+
+Especially important for healthcare message processing:
+
+```typescript
+// src/types/hpk.ts
+export type HPKMessageType = 'ID' | 'MV' | 'CV' | 'PR' | 'FO'
+export type HPKMode = 'C' | 'M' | 'D'
+
+export interface HPKMessage {
+  type: HPKMessageType
+  code: string
+  mode: HPKMode
+  sender: string
+  timestamp: string
+  userId: string
+  fields: string[]
+}
+
+// Discriminated union for type-safe message handling
+export type HPKIdentityMessage = HPKMessage & {
+  type: 'ID'
+  patient: {
+    id: string
+    lastName: string
+    firstName: string
+    birthDate: string
+    sex: 'M' | 'F'
+  }
+}
+
+export type HPKMovementMessage = HPKMessage & {
+  type: 'MV'
+  visit: {
+    id: string
+    unit: string
+    bed?: string
+  }
+}
+
+export type TypedHPKMessage = HPKIdentityMessage | HPKMovementMessage
+```
+
+## Phase 4: Tighten the Compiler
+
+Enable stricter checks one at a time. After each change, fix all errors before enabling the next.
+
+### Recommended Order
+
+```json
+// Step 1 — catch null/undefined bugs (highest value)
+"strictNullChecks": true
+
+// Step 2 — catch missing types
+"noImplicitAny": true
+
+// Step 3 — catch forgotten returns
+"noImplicitReturns": true
+
+// Step 4 — catch switch fallthrough
+"noFallthroughCasesInSwitch": true
+
+// Step 5 — full strict mode (enables all strict options)
+"strict": true
+```
+
+### Dealing with `strictNullChecks` Errors
+
+Most common patterns:
+
+```typescript
+// Problem: Object is possibly 'undefined'
+const patient = patients.find(p => p.id === id)
+patient.name  // Error!
+
+// Fix 1: Guard clause (preferred)
+if (!patient) {
+  throw new Error(`Patient ${id} not found`)
+}
+patient.name  // OK — TypeScript narrows the type
+
+// Fix 2: Optional chaining (when absence is expected)
+const name = patient?.name ?? 'Unknown'
+
+// Fix 3: Non-null assertion (LAST RESORT — avoid if possible)
+patient!.name  // Suppresses error, but defeats the purpose
+```
+
+### Eliminating `any`
+
+```typescript
+// STEP 1: Replace `any` with `unknown`
+function parseMessage(raw: unknown): HPKMessage {
+  if (typeof raw !== 'string') {
+    throw new Error('Expected string input')
+  }
+  // Now TypeScript knows raw is a string
+  const parts = raw.split('|')
+  // ...
+}
+
+// STEP 2: Use type guards for runtime checking
+function isPatient(data: unknown): data is Patient {
+  return (
+    typeof data === 'object' &&
+    data !== null &&
+    'id' in data &&
+    'lastName' in data
+  )
+}
+
+// STEP 3: Use Zod for validated parsing (recommended)
+import { z } from 'zod'
+
+const PatientSchema = z.object({
+  id: z.string(),
+  lastName: z.string(),
+  firstName: z.string(),
+  birthDate: z.string().regex(/^\d{4}-\d{2}-\d{2}$/),
+  sex: z.enum(['M', 'F', 'U']),
+})
+
+type Patient = z.infer<typeof PatientSchema>
+
+function parsePatient(data: unknown): Patient {
+  return PatientSchema.parse(data)  // Throws ZodError if invalid
+}
+```
+
+## Phase 5: Strict Mode
+
+When all files are `.ts` and all strict checks pass individually:
+
+```json
+{
+  "compilerOptions": {
+    "strict": true,
+    "allowJs": false,
+    "checkJs": false
+  }
+}
+```
+
+Remove `allowJs` since all files are now TypeScript.
+
+## Common Patterns for Legacy Code
+
+### Typing Callback-Heavy Code
+
+```typescript
+// Legacy pattern with callbacks
+function fetchData(url: string, callback: (err: Error | null, data?: unknown) => void): void
+
+// Modern replacement
+async function fetchData(url: string): Promise<unknown>
+```
+
+### Typing Dynamic Objects
+
+```typescript
+// When the shape varies at runtime (e.g., config, feature flags)
+type Config = Record<string, string | number | boolean>
+
+// When you know some keys but not all
+interface AppConfig {
+  apiUrl: string
+  debug: boolean
+  [key: string]: unknown  // Allow additional unknown keys
+}
+```
+
+### Typing Third-Party Libraries Without Types
+
+```typescript
+// Create src/types/untyped-lib.d.ts
+declare module 'legacy-hpk-decoder' {
+  export function decode(message: string): Record<string, string>
+  export function encode(fields: Record<string, string>): string
+}
+```
+
+### Typing Express Middleware
+
+```typescript
+import { Request, Response, NextFunction } from 'express'
+
+interface AuthenticatedRequest extends Request {
+  user: {
+    id: string
+    roles: string[]
+  }
+}
+
+function requireAuth(req: Request, res: Response, next: NextFunction): void {
+  const token = req.headers.authorization?.replace('Bearer ', '')
+  if (!token) {
+    res.status(401).json({ error: 'Unauthorized' })
+    return
+  }
+  // Attach user to request
+  ;(req as AuthenticatedRequest).user = verifyToken(token)
+  next()
+}
+```
+
+## Migration Checklist
+
+### Before Starting
+```
+[ ] Team aligned on migration (not a solo effort)
+[ ] Build pipeline supports .ts files
+[ ] IDE configured for TypeScript (tsserver)
+[ ] tsconfig.json created with permissive settings
+[ ] @types packages installed for dependencies
+```
+
+### Per File
+```
+[ ] File renamed .js → .ts (or .jsx → .tsx)
+[ ] Exported functions have explicit parameter and return types
+[ ] Complex objects have interfaces/types defined
+[ ] No new `any` introduced (use `unknown` + type guards)
+[ ] Tests still pass after conversion
+[ ] No `// @ts-ignore` or `// @ts-expect-error` (unless temporary, with TODO)
+```
+
+### Before Enabling Strict
+```
+[ ] All files are .ts/.tsx
+[ ] strictNullChecks enabled and all errors fixed
+[ ] noImplicitAny enabled and all errors fixed
+[ ] No remaining `any` in public APIs
+[ ] Shared types defined in types/ directory
+[ ] Type coverage > 90%
+```
+
+## Common Pitfalls
+
+| Pitfall | Why It's Bad | Fix |
+|---------|-------------|-----|
+| `as any` everywhere | Defeats the purpose of TypeScript | Use `unknown` + type guards |
+| Rewriting code during migration | Introduces bugs, blocks progress | Migrate types only, refactor later |
+| Starting with strict mode | Too many errors, team gives up | Start permissive, tighten gradually |
+| Migrating test files first | Tests don't need strict types | Migrate source first, tests last |
+| Giant PR with 50 files | Unreviewable, merge conflicts | One file or module per PR |
+| Ignoring `@types` packages | Missing types for dependencies | Install `@types/*` as you go |


### PR DESCRIPTION
## Summary

Deux nouveaux skills ciblés pour accélérer la vélocité des équipes sur les sujets legacy → modern :

- **testing-patterns** — Guide complet des patterns de test JS/TS : unitaire (AAA, table-driven, async), intégration (DB, API, messages HPK/HL7), E2E (Page Object, data-testid, régression visuelle), mocking (mock/stub/spy, MSW, time), organisation (colocation, factories), anti-patterns (flaky tests, snapshot abuse, over-mocking). Complète le skill `tdd` existant (workflow vs patterns).

- **typescript-migration** — Stratégie de migration incrémentale JS → TS en 5 phases : setup permissif, rename leaf-first, type boundaries (APIs, messages healthcare), tighten progressif (strictNullChecks → noImplicitAny → strict), et strict mode final. Inclut des exemples de typage spécifiques au domaine santé (HPK discriminated unions, HL7 segments).

Mise à jour des index : CLAUDE.md (34→36 skills), README.md et docs/README.md.

## Test plan
- [ ] Vérifier que `skills/testing-patterns/SKILL.md` a un frontmatter valide (name, description, version, license)
- [ ] Vérifier que `skills/typescript-migration/SKILL.md` a un frontmatter valide
- [ ] Vérifier que les docs sont en français
- [ ] Vérifier que les nouveaux skills apparaissent dans README.md et docs/README.md
- [ ] Vérifier la CI (Check SKILL.md frontmatter)

🤖 Generated with [Claude Code](https://claude.com/claude-code)