### PR TITLE
feat(hexagone-web-feature-extractor): optimize for reliability and generalizability

### DIFF
--- a/docs/hexagone-web-feature-extractor.md
+++ b/docs/hexagone-web-feature-extractor.md
@@ -1,10 +1,10 @@
 # Hexagone Web Feature Extractor
 
-Skill permettant d'explorer un espace Hexagone Web via Claude in Chrome, de capturer systématiquement chaque page/onglet, et de produire un document Word (.docx) orienté Product Owner avec descriptions fonctionnelles et captures d'écran embarquées.
+Skill permettant d'explorer **n'importe quel** espace Hexagone Web via Claude in Chrome, de capturer systématiquement chaque page/onglet, et de produire un document Word (.docx) orienté Product Owner avec descriptions fonctionnelles et captures d'écran embarquées.
 
 ## Cas d'usage
 
-- Explorer et documenter un espace fonctionnel Hexagone Web (ex : Structures / Nomenclatures)
+- Explorer et documenter un espace fonctionnel Hexagone Web (tout espace, pas uniquement Structures / Nomenclatures)
 - Produire une fiche produit ou une présentation client à partir des écrans Hexagone
 - Capturer l'intégralité des pages et onglets d'un module pour audit fonctionnel
 
@@ -14,6 +14,7 @@ Skill permettant d'explorer un espace Hexagone Web via Claude in Chrome, de capt
 - Accès réseau au serveur Hexagone Web (URL interne type `https://wsXXXXXX.dedalus.lan:PORT/hexagone-XX/vue/login`)
 - Certificat SSL accepté manuellement si auto-signé
 - Le skill **docx** doit être disponible pour la génération du document final
+- Dépendances Node.js : exécuter `npm install` dans le répertoire `scripts/`
 
 ## Workflow
 
@@ -22,8 +23,8 @@ Skill permettant d'explorer un espace Hexagone Web via Claude in Chrome, de capt
 2. NAVIGATION    → Accéder à l'espace cible
 3. DÉCOUVERTE    → Lister toutes les pages/menus du sidebar
 4. EXPLORATION   → Parcourir chaque page, capturer screenshots + texte
-5. TRANSFERT     → Transférer les screenshots vers le conteneur
-6. GÉNÉRATION    → Produire le document Word avec captures embarquées
+5. TRANSFERT     → Transférer les screenshots vers le conteneur (avec vérification)
+6. GÉNÉRATION    → Produire le document Word avec captures embarquées (avec validation JSON)
 ```
 
 ## Paramètres d'entrée
@@ -47,6 +48,8 @@ Le skill produit un fichier `.docx` structuré :
 
 - Skill [docx](docx.md) pour la génération du document Word
 - Scripts inclus : `generate-docx.js`, `screenshot-server.js`, `screenshot-bridge.md`
+- `package.json` avec dépendance `docx` (exécuter `npm install` avant la première utilisation)
+- Données d'exemple : `reference/default-structures-nomenclatures.json`
 
 ## Liens
 

--- a/skills/hexagone-web-feature-extractor/SKILL.md
+++ b/skills/hexagone-web-feature-extractor/SKILL.md
@@ -1,55 +1,71 @@
 ---
 name: hexagone-web-feature-extractor
-description: "Skill pour se connecter à Hexagone Web via Claude in Chrome, parcourir systématiquement un espace applicatif, capturer des screenshots de chaque page/onglet, et produire un document Word (.docx) orienté Product Owner avec descriptions fonctionnelles et captures d'écran embarquées. Utiliser ce skill dès que l'utilisateur demande d'explorer Hexagone Web, d'extraire des features, de documenter un espace fonctionnel, de produire une fiche produit ou une présentation client depuis Hexagone Web. Fonctionne aussi pour tout autre espace que Structures/Nomenclatures."
+description: "Explore any Hexagone Web space via Claude in Chrome, capture screenshots, and produce a PO-oriented Word document."
+version: 1.0.0
 ---
 
 # Hexagone Web Feature Extractor
 
-Skill permettant d'explorer un espace Hexagone Web, d'en capturer les écrans et de produire un document Word orienté PO/client.
+Explore a Hexagone Web functional space, capture screenshots of every page/tab, and produce a Word document (.docx) oriented for Product Owners with functional descriptions and embedded screenshots.
 
-## Prérequis
+## Prerequisites
 
-- **Claude in Chrome** activé et connecté
-- Accès réseau au serveur Hexagone Web (par défaut : `https://ws004202.dedalus.lan:8065/hexagone-01/vue/login`)
-- Acceptation manuelle du certificat SSL si auto-signé (l'utilisateur doit le faire avant de lancer le skill)
-- Le skill **docx** doit être disponible pour la génération du document final
+- **Claude in Chrome** enabled and connected
+- Network access to the Hexagone Web server (default: `https://ws004202.dedalus.lan:8065/hexagone-01/vue/login`)
+- SSL certificate manually accepted if self-signed (user must do this before launching the skill)
+- The **docx** skill must be available for final document generation
+- Node.js dependencies installed: run `npm install` in the `scripts/` directory
 
-## Vue d'ensemble du workflow
+## Configuration
+
+Default values calibrated for the standard Hexagone Web layout at 1920x1080. Adjust if the layout differs.
+
+| Parameter | Default | Description |
+|-----------|---------|-------------|
+| Sidebar click X coordinate | `38` | Horizontal pixel position for sidebar menu clicks |
+| Sidebar max left boundary | `250` | Max `rect.left` value to identify sidebar links |
+| Header height offset | `60` | Min `rect.top` value to exclude header elements |
+| Login wait timeout | `20s` | Max time to poll for successful login |
+| Page load wait timeout | `10s` | Max time to poll for page load after navigation |
+| Screenshot bridge port | `8765` | HTTP port for the screenshot bridge server |
+| Screenshots directory | `/home/claude/screenshots` | Where screenshots are saved (configurable via `--screenshots` arg) |
+
+## Workflow Overview
 
 ```
-1. CONNEXION     → Se connecter à Hexagone Web via Chrome
-2. NAVIGATION    → Accéder à l'espace cible
-3. DÉCOUVERTE    → Lister toutes les pages/menus du sidebar
-4. EXPLORATION   → Parcourir chaque page, capturer screenshots + texte
-5. TRANSFERT     → Transférer les screenshots vers le conteneur
-6. GÉNÉRATION    → Produire le document Word avec captures embarquées
+1. CONNECTION   → Log in to Hexagone Web via Chrome
+2. NAVIGATION   → Navigate to the target space
+3. DISCOVERY    → List all sidebar menu pages
+4. EXPLORATION  → Visit each page, capture screenshots + metadata
+5. TRANSFER     → Transfer screenshots to the container filesystem
+6. GENERATION   → Produce the Word document with embedded screenshots
 ```
 
 ---
 
-## Étape 1 : Connexion à Hexagone Web
+## Step 1: Connection to Hexagone Web
 
-### 1.1 Préparer l'onglet Chrome
+### 1.1 Prepare the Chrome Tab
 
 ```
-1. Appeler tabs_context_mcp(createIfEmpty=true) pour obtenir un onglet
-2. Créer un nouvel onglet dédié : tabs_create_mcp()
-3. Naviguer vers l'URL de login (par défaut `https://ws004202.dedalus.lan:8065/hexagone-01/vue/login`, sauf si l'utilisateur en fournit une autre)
+1. Call tabs_context_mcp(createIfEmpty=true) to get a tab
+2. Create a dedicated tab: tabs_create_mcp()
+3. Navigate to the login URL (default: `https://ws004202.dedalus.lan:8065/hexagone-01/vue/login`, unless the user provides another)
 ```
 
-**IMPORTANT** : La navigation initiale peut échouer (timeout) si le certificat SSL n'est pas accepté. Dans ce cas :
-- Demander à l'utilisateur de cliquer manuellement sur "Paramètres avancés" > "Continuer vers le site"
-- Attendre que la page de login soit affichée
-- Reprendre le contrôle
+**IMPORTANT**: Initial navigation may fail (timeout) if the SSL certificate is not accepted. In that case:
+- Ask the user to manually click "Advanced" > "Continue to site"
+- Wait for the login page to display
+- Resume control
 
-### 1.2 Remplir le formulaire de login
+### 1.2 Fill the Login Form
 
-Le formulaire Hexagone Web a 3 champs : Nom utilisateur, Mot de passe, Code gestionnaire. Par défaut, utiliser l'utilisateur `apvhn` avec un mot de passe aléatoire, sauf si l'utilisateur en fournit d'autres.
+The Hexagone Web login form has 3 fields: Username, Password, Manager code. Default credentials: username `apvhn` with a random password, unless the user provides others.
 
-**Méthode recommandée** : Utiliser JavaScript natif pour remplir les champs. La méthode `form_input` fonctionne mais le clic sur le bouton peut échouer (`chrome-extension:// URL` error). Utiliser JavaScript pour tout le processus :
+**Recommended method**: Use native JavaScript to fill the fields. The `form_input` method works but button clicks may fail (`chrome-extension:// URL` error). Use JavaScript for the entire process:
 
 ```javascript
-// Remplir via JavaScript avec dispatch d'événements (nécessaire pour Vue.js)
+// Fill via JavaScript with event dispatching (required for Vue.js)
 const nativeSetter = Object.getOwnPropertyDescriptor(
   window.HTMLInputElement.prototype, 'value'
 ).set;
@@ -66,45 +82,47 @@ nativeSetter.call(pwdInput, 'Rand' + Math.random().toString(36).slice(2, 10));
 pwdInput.dispatchEvent(new Event('input', { bubbles: true }));
 pwdInput.dispatchEvent(new Event('change', { bubbles: true }));
 
-// Cliquer sur "Se connecter"
-document.querySelector('button').click();
+// Click the login button — use text content to avoid selecting the wrong button
+const buttons = Array.from(document.querySelectorAll('button'));
+const loginBtn = buttons.find(b => /connect/i.test(b.textContent));
+if (loginBtn) loginBtn.click();
 ```
 
-**Pourquoi JavaScript ?** Le framework Vue.js d'Hexagone Web ne détecte pas les changements de valeur injectés directement. Le `nativeInputValueSetter` + `dispatchEvent('input')` simule une saisie utilisateur réelle.
+**Why JavaScript?** The Vue.js framework in Hexagone Web does not detect value changes injected directly. The `nativeInputValueSetter` + `dispatchEvent('input')` simulates real user input.
 
-### 1.3 Vérifier la connexion
+### 1.3 Verify Connection
 
-Après le clic, attendre 5s puis vérifier :
-- Le titre de l'onglet change (ex: "Hexagone Web - Portail patient")
-- Un screenshot montre la page d'accueil avec le message "Bienvenue sur l'espace..."
+After clicking, **poll every 2s for up to 20s** until one of these conditions is met:
+- The tab title changes (e.g., "Hexagone Web - Portail patient")
+- A screenshot shows the home page with the "Bienvenue sur l'espace..." message
+
+**If login fails after 20s**: Check for an error message element on the page (`document.querySelector('.error, .alert, [role="alert"]')`) and report the failure reason to the user.
 
 ---
 
-## Étape 2 : Navigation vers l'espace cible
+## Step 2: Navigation to the Target Space
 
-### 2.1 Ouvrir le sélecteur d'espaces
+### 2.1 Open the Space Selector
 
-L'espace actif est affiché dans la barre orange en haut (ex: "PORTAIL PATIENT"). Cliquer dessus pour ouvrir la liste déroulante de tous les espaces disponibles.
+The active space is displayed in the orange bar at the top (e.g., "PORTAIL PATIENT"). Click on it to open the dropdown list of all available spaces.
 
-```
-Coordonnée approximative : cliquer sur le texte orange de l'espace actif dans le breadcrumb
-```
+### 2.2 Select the Space
 
-### 2.2 Sélectionner l'espace
+The dropdown (orange background) may require scrolling. Spaces are listed alphabetically. Scroll and click on the desired space.
 
-La liste déroulante (fond orange) peut nécessiter un scroll. Les espaces sont listés alphabétiquement. Scroller et cliquer sur l'espace souhaité (ex: "STRUCTURES / NOMENCLATURES").
+### 2.3 Wait for Loading
 
-### 2.3 Attendre le chargement
-
-Hexagone Web redirige via une page intermédiaire "Connexion... Redirection...". Attendre 5s minimum et vérifier que l'URL a changé et que le breadcrumb affiche le nouvel espace.
+Hexagone Web redirects via an intermediate "Connexion... Redirection..." page. **Poll every 2s for up to 15s** until:
+- The URL has changed
+- The breadcrumb displays the new space name
 
 ---
 
-## Étape 3 : Découverte des pages
+## Step 3: Page Discovery
 
-### 3.1 Identifier les entrées du menu latéral
+### 3.1 Identify Sidebar Menu Entries
 
-Le menu latéral (sidebar gauche) contient des icônes sans texte visible par défaut. Utiliser JavaScript pour les lister :
+The sidebar (left side) contains icons without visible text by default. Use JavaScript to list them:
 
 ```javascript
 const links = document.querySelectorAll('a.hexa');
@@ -122,43 +140,63 @@ links.forEach(el => {
 JSON.stringify(items, null, 2);
 ```
 
-**Structure typique du sidebar** : Les liens ont la classe CSS `hexa`. Le texte est préfixé par le nom de l'icône (ex: `tdbTableau de bord`, `lettres_budgetLettres budgets`). Extraire la partie après le préfixe d'icône.
+**Typical sidebar structure**: Links have the CSS class `hexa`. The text is prefixed by the icon name (e.g., `tdbTableau de bord`, `lettres_budgetLettres budgets`). Extract the part after the icon prefix.
 
-### 3.2 Construire le plan d'exploration
+### 3.2 Validation Gate
 
-Créer une liste ordonnée de toutes les pages à visiter, avec leurs coordonnées Y pour le clic. Exclure les pages utilitaires (Tableau de bord, Mes post-its) si non pertinentes pour le livrable PO.
+**IMPORTANT**: After collecting items, verify the result:
+
+```javascript
+if (items.length === 0) {
+  // Primary selector failed — try fallback selectors
+  const fallbackLinks = document.querySelectorAll(
+    '[data-menu-item], nav a, .sidebar a, .v-navigation-drawer a'
+  );
+  // Retry with wider bounding box: rect.left < 350 && rect.top > 40
+  // If still zero items: STOP and report failure with DOM state
+}
+```
+
+**If zero items are found after fallback**: Stop the exploration and report the failure. Do NOT proceed to Step 4 with an empty page list — this would produce an empty document.
+
+### 3.3 Build the Exploration Plan
+
+Create an ordered list of all pages to visit, with their Y coordinates for clicking. Exclude utility pages (Tableau de bord, Mes post-its) if not relevant to the PO deliverable.
 
 ---
 
-## Étape 4 : Exploration et capture
+## Step 4: Exploration and Capture
 
-### 4.1 Pour chaque page du menu
+### 4.1 For Each Page in the Menu
 
 ```
-1. Cliquer sur l'entrée du menu (utiliser la coordonnée Y avec x=38)
-   - Si le clic direct échoue, utiliser JavaScript : el.click()
-2. Attendre 3 secondes le chargement
-3. Prendre un screenshot : computer(action="screenshot", save_to_disk=true)
-4. Extraire les informations textuelles clés via read_page ou JavaScript
-5. Si la page a des onglets, les parcourir un par un
-6. Si la page a des sous-pages (ex: Paramétrages > Banques), les explorer
-7. Stocker l'ID du screenshot et les métadonnées dans une liste
+1. Click on the menu entry (use the Y coordinate with x=38)
+   - If direct click fails, use JavaScript: el.click()
+2. Poll every 1s for up to 10s until the main content area has changed
+   (compare URL fragment or main content container innerHTML before/after)
+3. Take a screenshot: computer(action="screenshot", save_to_disk=true)
+4. Extract key textual information via read_page or JavaScript
+5. If the page has tabs, iterate through them one by one
+6. If the page has sub-pages, explore them
+7. Store the screenshot ID and metadata in a list
 ```
 
-### 4.2 Identifier les onglets internes
+### 4.2 Identify Internal Tabs
 
-Certaines pages ont des onglets internes (ex: Plan comptable → Comptes de résultat / Tableau de financement / Comptes de tiers). Les trouver avec :
+Some pages have internal tabs (e.g., Plan comptable → Comptes de résultat / Tableau de financement / Comptes de tiers). Find them with:
 
 ```javascript
-// Chercher les onglets
-const tabs = document.querySelectorAll('[role="tab"], .tab-link, a[href="javascript:;"]');
+// Look for tabs by structural role
+const tabs = document.querySelectorAll('[role="tab"]');
+// Fallback if no ARIA roles
+if (tabs.length === 0) {
+  const tabLinks = document.querySelectorAll('.tab-link, .v-tab, [data-tab]');
+}
 ```
 
-Ou utiliser `find(query="tab")` pour les localiser.
+### 4.3 Store Metadata
 
-### 4.3 Stocker les métadonnées
-
-Maintenir un tableau JSON des pages explorées :
+Maintain a JSON array of explored pages:
 
 ```json
 [
@@ -166,7 +204,7 @@ Maintenir un tableau JSON des pages explorées :
     "id": 1,
     "page": "Tableau de bord",
     "screenshotId": "ss_XXXXX",
-    "description": "Vue synthétique par exercice...",
+    "description": "Synthetic view by fiscal year...",
     "tabs": [],
     "subpages": []
   }
@@ -175,53 +213,99 @@ Maintenir un tableau JSON des pages explorées :
 
 ---
 
-## Étape 5 : Transfert des screenshots vers le conteneur
+## Step 5: Screenshot Transfer to the Container
 
-### Problème connu
+### Known Limitation
 
-Les screenshots pris via `computer(action="screenshot")` sont stockés en mémoire par l'extension Chrome avec un ID (ex: `ss_49478g4in`). Ils ne sont **pas** directement accessibles depuis le filesystem du conteneur (`/home/claude/`).
+Screenshots taken via `computer(action="screenshot")` are stored in memory by the Chrome extension with an ID (e.g., `ss_49478g4in`). They are **not** directly accessible from the container filesystem (`/home/claude/`).
 
-### Solution : Bridge HTTP
+### Solution: HTTP Bridge
 
-Lire le fichier `scripts/screenshot-bridge.md` pour la procédure complète de transfert des screenshots du navigateur vers le conteneur.
+Read the file `scripts/screenshot-bridge.md` for the complete transfer procedure.
 
-**Résumé** :
-1. Lancer un serveur HTTP dans le conteneur (`scripts/screenshot-server.js`)
-2. Naviguer un onglet Chrome vers la page bridge (`http://localhost:PORT/bridge.html`)
-3. Pour chaque screenshot, utiliser `upload_image(imageId, tabId, ref)` pour l'uploader via le file input de la page bridge
-4. JavaScript sur la page envoie le fichier au serveur qui le sauvegarde
-5. Les fichiers sont disponibles dans `/home/claude/screenshots/`
+**Summary**:
+1. Start an HTTP server in the container (`scripts/screenshot-server.js`)
+2. Navigate a Chrome tab to the bridge page (`http://localhost:8765/bridge.html`)
+3. For each screenshot, use `upload_image(imageId, tabId, ref)` to upload via the bridge page's file input
+4. JavaScript on the page sends the file to the server which saves it
+5. Files are available in the screenshots directory
+
+### Verification Gate
+
+**IMPORTANT**: Before proceeding to Step 6, verify the screenshot transfer:
+
+```bash
+# Count files in screenshots directory
+ls -1 /home/claude/screenshots/ | wc -l
+```
+
+Compare the count against the expected number of screenshots from Step 4. If screenshots are missing:
+- Report which specific screenshots failed to transfer (compare filenames against the metadata list)
+- Attempt to re-transfer missing screenshots
+- If re-transfer fails, proceed to Step 6 but warn the user that the document will contain placeholder boxes for missing screenshots
 
 ---
 
-## Étape 6 : Génération du document Word
+## Step 6: Word Document Generation
 
-### 6.1 Lire le skill docx
+### 6.1 Prepare the Input
 
-Toujours lire `/mnt/skills/public/docx/SKILL.md` avant de générer le document.
+Create a `features.json` file from the metadata collected in Step 4. The file must conform to this structure:
 
-### 6.2 Générer le document
-
-Utiliser le script `scripts/generate-docx.js` comme base. Le script :
-- Prend en entrée un fichier JSON de métadonnées (pages, descriptions, chemins screenshots)
-- Génère un .docx avec page de couverture, sommaire, et une section par feature
-- Chaque section inclut : titre, description PO, tableau des fonctionnalités clés, valeur métier, et screenshot embarqué
-
-### 6.3 Structure du document
-
-```
-Page de couverture (couleurs Dedalus teal/orange)
-Sommaire
-Pour chaque feature :
-  - Titre (Heading 2, orange)
-  - Description fonctionnelle
-  - Screenshot de la page
-  - Tableau "Fonctionnalités clés" (numéroté, fond teal)
-  - Section "Valeur métier" (titre orange)
-[Pas de synthèse finale - le document est auto-porteur par feature]
+```json
+{
+  "space": "Name of the explored space",
+  "features": [
+    {
+      "title": "Feature name (string, required)",
+      "description": "PO-oriented functional description (string, required)",
+      "capabilities": ["Capability 1", "Capability 2"],
+      "businessValue": "Business value description (string)",
+      "screenshots": [
+        { "file": "filename.jpg", "caption": "Screenshot description" }
+      ]
+    }
+  ]
+}
 ```
 
-### 6.4 Validation et sortie
+**Validation rules:**
+- `space` must be a non-empty string
+- `features` must be a non-empty array
+- Each feature must have `title` (string) and `description` (string)
+- `capabilities` must be an array of strings (can be empty)
+- `screenshots` must be an array of objects with `file` (string) and `caption` (string)
+
+### 6.2 Read the docx Skill
+
+Always read the docx skill before generating the document.
+
+### 6.3 Generate the Document
+
+Use the script `scripts/generate-docx.js`:
+
+```bash
+cd scripts && npm install  # First time only
+node generate-docx.js --input features.json --output /path/to/output.docx --screenshots /path/to/screenshots
+```
+
+The `--input` argument is **required**. The script validates the input and fails with clear error messages if the JSON is malformed.
+
+### 6.4 Document Structure
+
+```
+Cover page (Dedalus teal/orange branding)
+Table of contents
+For each feature:
+  - Title (Heading 2, orange)
+  - Functional description
+  - Screenshot of the page
+  - "Key capabilities" table (numbered, teal background)
+  - "Business value" section (orange title)
+[No final summary — the document is self-contained per feature]
+```
+
+### 6.5 Validation and Output
 
 ```bash
 python /mnt/skills/public/docx/scripts/office/validate.py output.docx
@@ -230,20 +314,26 @@ cp output.docx /mnt/user-data/outputs/
 
 ---
 
-## Paramètres d'entrée attendus
+## Input Parameters
 
-L'utilisateur doit fournir :
-- **URL de login** *(optionnel)* : par défaut `https://ws004202.dedalus.lan:8065/hexagone-01/vue/login` (environnement de développement). L'utilisateur peut fournir une autre URL si nécessaire.
-- **Nom utilisateur** *(optionnel)* : par défaut `apvhn`. L'utilisateur peut fournir un autre code si nécessaire.
-- **Mot de passe** *(optionnel)* : par défaut une valeur aléatoire. L'utilisateur peut fournir un mot de passe spécifique si nécessaire.
-- **Espace cible** : nom exact de l'espace à explorer (ex: "STRUCTURES / NOMENCLATURES")
+The user must provide:
+- **Login URL** *(optional)*: defaults to `https://ws004202.dedalus.lan:8065/hexagone-01/vue/login`. The user can provide a different URL if needed.
+- **Username** *(optional)*: defaults to `apvhn`. The user can provide a different code if needed.
+- **Password** *(optional)*: defaults to a random value. The user can provide a specific password if needed.
+- **Target space**: Exact name of the space to explore (e.g., "STRUCTURES / NOMENCLATURES")
 
 ## Troubleshooting
 
-| Problème | Cause | Solution |
-|----------|-------|----------|
-| Navigation timeout | Certificat SSL | Utilisateur accepte manuellement |
-| `chrome-extension:// URL` error | Focus sur popup extension | Utiliser JavaScript au lieu de click direct |
-| Champs non détectés par Vue.js | Injection directe sans events | Utiliser `nativeInputValueSetter` + `dispatchEvent` |
-| Menu déroulant non visible | Scroll nécessaire | `scroll(direction="down")` dans le menu |
-| Screenshot non accessible | Stockage en mémoire extension | Utiliser le bridge HTTP (étape 5) |
+| Problem | Cause | Solution |
+|---------|-------|----------|
+| Navigation timeout | SSL certificate not accepted | User must accept manually |
+| `chrome-extension:// URL` error | Focus on extension popup | Use JavaScript instead of direct click |
+| Fields not detected by Vue.js | Direct injection without events | Use `nativeInputValueSetter` + `dispatchEvent` |
+| Dropdown menu not visible | Scroll needed | `scroll(direction="down")` in the menu |
+| Screenshot not accessible from filesystem | Stored in Chrome extension memory | Use the HTTP bridge (Step 5) |
+| Zero menu items discovered | CSS class `a.hexa` not matching | Try fallback selectors (see Step 3.2) |
+| Login button click selects wrong button | Multiple buttons on page | Use text-content matching: `buttons.find(b => /connect/i.test(b.textContent))` |
+| Page content not loaded after click | Slow server or heavy page | Use poll-based waiting instead of fixed delay |
+| Screenshot bridge upload fails | Port 8765 already in use | Check port availability, try port 8766-8775 |
+| Generated document has placeholder boxes | Screenshots not transferred | Run verification gate (Step 5) before generation |
+| `generate-docx.js` fails with validation error | Malformed features.json | Check required fields: `space`, `features[].title`, `features[].description` |

--- a/skills/hexagone-web-feature-extractor/reference/default-structures-nomenclatures.json
+++ b/skills/hexagone-web-feature-extractor/reference/default-structures-nomenclatures.json
@@ -1,0 +1,129 @@
+{
+  "space": "Structures / Nomenclatures",
+  "features": [
+    {
+      "title": "Tableau de bord synthétique",
+      "description": "Le tableau de bord offre une vue consolidée et immédiate de la structure budgétaire de l\u2019établissement, par exercice comptable. Il affiche en un coup d\u2019œil les indicateurs clés : nombre d\u2019entités juridiques, lettres budgets actives, unités fonctionnelles validées et comptes ordonnateurs. Un graphique camembert permet de visualiser la répartition par établissement.",
+      "capabilities": [
+        "Vue multi-exercice (N et N-1) avec comparaison des indicateurs clés",
+        "Indicateur de validation de structure (pastille verte/orange) avec date et responsable",
+        "Onglets dédiés : Lettres Budgets, UF Valides, Comptes Ordonnateurs",
+        "Graphique de répartition par entité juridique (camembert interactif)",
+        "Widget Post-its intégré avec tri par importance et par émetteur",
+        "Affichage du nombre total de comptes ordonnateurs par exercice"
+      ],
+      "businessValue": "Permet aux décideurs et aux gestionnaires financiers de piloter la cohérence de la structure budgétaire en temps réel. La comparaison inter-exercices facilite le suivi de l\u2019évolution et la préparation des EPRD.",
+      "screenshots": [{ "file": "01-tableau-de-bord.jpg", "caption": "Tableau de bord avec exercices 2025 et 2026, graphiques de répartition par établissement" }]
+    },
+    {
+      "title": "Post-its collaboratifs",
+      "description": "Système de messagerie interne légère permettant aux utilisateurs d\u2019échanger des notes contextualisées directement dans l\u2019espace de travail. Les post-its peuvent être classés par importance (Urgent, Important, Normal) et filtrés par émetteur.",
+      "capabilities": [
+        "Création de post-its avec niveau de priorité (Urgent / Important / Normal)",
+        "Vue des post-its envoyés et reçus",
+        "Tri par importance ou par émetteur",
+        "Compteurs synthétiques sur le tableau de bord"
+      ],
+      "businessValue": "Favorise la communication inter-équipes sans quitter l\u2019application. Particulièrement utile pour les échanges entre DAF, contrôle de gestion et cellule budgétaire lors des campagnes EPRD.",
+      "screenshots": [{ "file": "02-post-its.jpg", "caption": "Écran Mes Post-its (envoyés) avec bouton d\u2019ajout" }]
+    },
+    {
+      "title": "Regroupement multi-entités juridiques (GHT)",
+      "description": "Cet écran permet de configurer et de gérer le Groupement Hospitalier de Territoire (GHT) auquel l\u2019établissement est rattaché. Il centralise les informations réglementaires (date d\u2019approbation ARS, SIRET, profil acheteur) et les paramètres de gestion mutualisée des achats.",
+      "capabilities": [
+        "Fiche GHT complète : dénomination, date ARS, SIRET, URL profil acheteur",
+        "Configuration du module HA GHT : gestion centralisée / non centralisée / non mis en œuvre",
+        "Numérotation automatique fournisseurs et produits avec compteur paramétrable",
+        "Liste des entités juridiques adhérentes avec codes FINESS",
+        "Identification du site support GHT et du SIH Hexagone",
+        "Accès rapides vers les fiches détaillées de chaque EJ"
+      ],
+      "businessValue": "Répond aux obligations réglementaires liées à la mutualisation des achats en GHT. Simplifie le paramétrage initial et la gestion courante des regroupements multi-établissements.",
+      "screenshots": [{ "file": "03-ght.jpg", "caption": "Formulaire GHT avec entités juridiques adhérentes" }]
+    },
+    {
+      "title": "Lettres budgets",
+      "description": "Gestion centralisée des lettres budgets de l\u2019établissement pour chaque exercice comptable. Chaque lettre budget (A à M) correspond à un périmètre fonctionnel (Budget général, EHPAD, IFSI, Long séjour, Centre de santé, GHT, etc.) avec sa nomenclature comptable associée (M21).",
+      "capabilities": [
+        "Liste complète des lettres budgets par exercice avec libellé et nomenclature",
+        "Création et paramétrage de nouvelles lettres budgets",
+        "Dépliage hiérarchique pour visualiser les détails de chaque lettre",
+        "Sélection d\u2019exercice (2025, 2026…) avec statut de validation",
+        "Détection d\u2019anomalies intégrée",
+        "Export des données"
+      ],
+      "businessValue": "Offre une vision structurée de l\u2019ensemble des budgets annexes et du budget principal. Essentiel pour la préparation du Budget Initial, de l\u2019EPRD et du suivi infra-annuel dans le respect de la nomenclature M21.",
+      "screenshots": [{ "file": "04-lettres-budgets.jpg", "caption": "Liste des lettres budgets A à M avec nomenclature M21" }]
+    },
+    {
+      "title": "Découpages comptable",
+      "description": "Module de gestion du découpage analytique de l\u2019établissement, organisé en deux axes : les unités fonctionnelles (UF) et les pôles / niveaux de regroupements. Ce module permet de structurer l\u2019organigramme budgétaire de l\u2019hôpital.",
+      "capabilities": [
+        "Onglet Unités Fonctionnelles : recherche multi-critères (UF, libellé, EJ, lettre budget GHT, dates)",
+        "Onglet Pôles et Niveaux de Regroupements : gestion des natures et hiérarchies",
+        "Ajout d\u2019UF, de natures et de regroupements",
+        "Filtrage par lettre budget GHT et entité juridique",
+        "Export au format CSV (tableur)",
+        "Réinitialisation des filtres de recherche"
+      ],
+      "businessValue": "Permet d\u2019aligner le découpage comptable avec l\u2019organisation médicale en pôles. Indispensable pour le suivi analytique par UF, la contractualisation interne et le reporting réglementaire (RTC, SAE).",
+      "screenshots": [
+        { "file": "05a-decoupages-uf.jpg", "caption": "Onglet Unités Fonctionnelles avec formulaire de recherche" },
+        { "file": "05b-decoupages-poles.jpg", "caption": "Onglet Pôles et Niveaux de Regroupements" }
+      ]
+    },
+    {
+      "title": "Plan comptable",
+      "description": "Consultation et gestion du plan comptable de l\u2019établissement, découpé en trois vues complémentaires : comptes de résultat, tableau de financement et comptes de tiers. L\u2019arborescence est organisée par lettre budget et conforme à la nomenclature M21.",
+      "capabilities": [
+        "Onglet Comptes de Résultat : arbre charges/produits par lettre budget dépliable",
+        "Onglet Tableau de Financement : vue emplois/ressources par lettre budget",
+        "Onglet Comptes de Tiers : liste paginée (593 comptes) avec recherche par code ou libellé",
+        "Filtres avancés : niveau ordonnateur, nature, chapitre, nomenclature, exécutoire",
+        "Actions d\u2019édition en ligne sur les comptes de tiers",
+        "Extraction CSV et fonctions replier/déplier",
+        "Ajout de comptes de tiers"
+      ],
+      "businessValue": "Donne aux équipes financières une vision complète et navigable du plan comptable M21. Facilite la gestion quotidienne des imputations, la création de comptes de tiers et les contrôles de cohérence.",
+      "screenshots": [
+        { "file": "06a-plan-comptable-resultat.jpg", "caption": "Comptes de résultat avec arborescence par lettre budget" },
+        { "file": "06b-plan-comptable-financement.jpg", "caption": "Tableau de financement" },
+        { "file": "06c-plan-comptable-tiers.jpg", "caption": "Comptes de tiers avec recherche et pagination" }
+      ]
+    },
+    {
+      "title": "Paramétrages généraux",
+      "description": "Hub de paramétrage centralisé organisé en trois catégories thématiques : Structures (données de référence), Récupération (import de données externes) et Historique (suivi des évolutions budgétaires).",
+      "capabilities": [
+        "Structures : Banques, Nationalités, Communes, Codes postaux, Civilités — chaque rubrique avec formulaire de recherche, ajout et import fichier",
+        "Récupération : Import de Comptes ordonnateurs, Historiques, Recettes diverses, GEF avec filtres (exercice, type, état d\u2019intégration)",
+        "Historique : Masse financière et Consommations pour le suivi pluriannuel",
+        "Chaque sous-module possède son propre formulaire de recherche avancée",
+        "Fonctions d\u2019intégration avec validation",
+        "Import par fichier pour chargement en masse"
+      ],
+      "businessValue": "Centralise le paramétrage de toutes les données de référence nécessaires au fonctionnement de l\u2019ERP. Les fonctions d\u2019import facilitent la reprise de données et la mise à jour en masse lors des changements réglementaires.",
+      "screenshots": [
+        { "file": "07a-parametrages-hub.jpg", "caption": "Hub de paramétrage avec 3 colonnes thématiques" },
+        { "file": "07b-parametrages-banques.jpg", "caption": "Sous-page Banques avec formulaire de recherche" }
+      ]
+    },
+    {
+      "title": "Référentiel GAP",
+      "description": "Gestion des nomenclatures et référentiels utilisés par le module GAP (Gestion Administrative du Patient). Trois niveaux sont distingués : livrés (Dedalus), nationaux (réglementaires) et téléchargés (mis à jour périodiquement).",
+      "capabilities": [
+        "Onglet Livrés (16 nomenclatures) : Codes proches, Lettres clé B2/DRE, Modes de PEC, Pièces justificatives, Protections civiles, Titres de praticiens, etc.",
+        "Onglet Nationaux (8 référentiels) : Activités socioprofessionnelles, Codes GIR, Disciplines Médico-Tarifaires, Spécialités médicales, etc.",
+        "Onglet Téléchargés (10 référentiels versionnés) : CCAM v82, NABM v93, LPP v800, GHS/GHT, UCD v715, COG, ICR, RIHN, ATU, Organismes SESAM-Vitale",
+        "Filtre de recherche par nom de nomenclature",
+        "Indicateur de version et date de mise à jour pour chaque référentiel"
+      ],
+      "businessValue": "Garantit la conformité réglementaire en centralisant tous les référentiels nécessaires à la facturation, l\u2019identito-vigilance et la gestion du parcours patient. Le versionnement assure une traçabilité complète des mises à jour.",
+      "screenshots": [
+        { "file": "08a-referentiel-livres.jpg", "caption": "Référentiels livrés (16 nomenclatures)" },
+        { "file": "08b-referentiel-nationaux.jpg", "caption": "Référentiels nationaux" },
+        { "file": "08c-referentiel-telecharges.jpg", "caption": "Référentiels téléchargés avec versions" }
+      ]
+    }
+  ]
+}

--- a/skills/hexagone-web-feature-extractor/scripts/generate-docx.js
+++ b/skills/hexagone-web-feature-extractor/scripts/generate-docx.js
@@ -1,26 +1,26 @@
 /**
  * Hexagone Web Feature Extractor — DOCX Generator
- * 
+ *
  * Usage:
  *   node generate-docx.js --input features.json --output document.docx [--screenshots /path/to/screenshots]
- * 
- * Or: node generate-docx.js  (uses default embedded data)
- * 
- * features.json format:
+ *
+ * The --input argument is REQUIRED. The input file must be a JSON file with this structure:
  * {
- *   "space": "Structures / Nomenclatures",
+ *   "space": "Space Name",
  *   "features": [
  *     {
- *       "title": "Tableau de bord",
- *       "description": "Vue synthétique...",
+ *       "title": "Feature title",
+ *       "description": "PO-oriented description",
  *       "capabilities": ["Cap 1", "Cap 2"],
- *       "businessValue": "Permet de...",
+ *       "businessValue": "Business value text",
  *       "screenshots": [
- *         { "file": "01-tableau-de-bord.jpg", "caption": "Tableau de bord exercice 2026" }
+ *         { "file": "screenshot.jpg", "caption": "Caption text" }
  *       ]
  *     }
  *   ]
  * }
+ *
+ * A sample input file is available at: reference/default-structures-nomenclatures.json
  */
 
 const fs = require('fs');
@@ -50,6 +50,62 @@ const getArg = (name) => { const i = args.indexOf(name); return i >= 0 ? args[i 
 const SCREENSHOT_DIR = getArg('--screenshots') || '/home/claude/screenshots';
 const OUTPUT_PATH = getArg('--output') || '/home/claude/hexagone-features.docx';
 
+// ─── Input validation ───
+function validateInput(data, filePath) {
+  const errors = [];
+
+  if (!data || typeof data !== 'object') {
+    errors.push('Input must be a JSON object');
+    return errors;
+  }
+
+  if (!data.space || typeof data.space !== 'string') {
+    errors.push('Missing or invalid "space" field (must be a non-empty string)');
+  }
+
+  if (!Array.isArray(data.features) || data.features.length === 0) {
+    errors.push('Missing or empty "features" array (must contain at least one feature)');
+    return errors;
+  }
+
+  data.features.forEach((feature, i) => {
+    const prefix = `features[${i}]`;
+
+    if (!feature.title || typeof feature.title !== 'string') {
+      errors.push(`${prefix}.title is missing or not a string`);
+    }
+
+    if (!feature.description || typeof feature.description !== 'string') {
+      errors.push(`${prefix}.description is missing or not a string`);
+    }
+
+    if (feature.capabilities !== undefined && !Array.isArray(feature.capabilities)) {
+      errors.push(`${prefix}.capabilities must be an array of strings`);
+    } else if (Array.isArray(feature.capabilities)) {
+      feature.capabilities.forEach((cap, j) => {
+        if (typeof cap !== 'string') {
+          errors.push(`${prefix}.capabilities[${j}] must be a string`);
+        }
+      });
+    }
+
+    if (feature.screenshots !== undefined && !Array.isArray(feature.screenshots)) {
+      errors.push(`${prefix}.screenshots must be an array`);
+    } else if (Array.isArray(feature.screenshots)) {
+      feature.screenshots.forEach((ss, j) => {
+        if (!ss.file || typeof ss.file !== 'string') {
+          errors.push(`${prefix}.screenshots[${j}].file must be a string`);
+        }
+        if (ss.caption !== undefined && typeof ss.caption !== 'string') {
+          errors.push(`${prefix}.screenshots[${j}].caption must be a string`);
+        }
+      });
+    }
+  });
+
+  return errors;
+}
+
 // ─── Screenshot helper ───
 function tryLoadImage(filename) {
   if (!filename) return null;
@@ -69,13 +125,11 @@ function tryLoadImage(filename) {
 }
 
 function screenshotParagraph(screenshotInfo) {
-  // screenshotInfo: { file: "xxx.jpg", caption: "Description" }
   if (!screenshotInfo) return [];
 
   const img = tryLoadImage(screenshotInfo.file);
 
   if (img) {
-    // Embedded image — scale to fit page width (9360 DXA ≈ 6.5 inches ≈ 624px at 96dpi)
     return [
       new Paragraph({
         spacing: { before: 120, after: 40 },
@@ -84,7 +138,7 @@ function screenshotParagraph(screenshotInfo) {
           type: img.type,
           data: img.data,
           transformation: { width: 620, height: 310 },
-          altText: { 
+          altText: {
             title: screenshotInfo.caption || "Screenshot",
             description: screenshotInfo.caption || "Capture d'écran Hexagone Web",
             name: screenshotInfo.file || "screenshot"
@@ -226,140 +280,38 @@ function featureSection(feature, index) {
   return children;
 }
 
-// ─── Default data: Structures / Nomenclatures ───
-const DEFAULT_DATA = {
-  space: "Structures / Nomenclatures",
-  features: [
-    {
-      title: "Tableau de bord synth\u00E9tique",
-      description: "Le tableau de bord offre une vue consolid\u00E9e et imm\u00E9diate de la structure budg\u00E9taire de l\u2019\u00E9tablissement, par exercice comptable. Il affiche en un coup d\u2019\u0153il les indicateurs cl\u00E9s : nombre d\u2019entit\u00E9s juridiques, lettres budgets actives, unit\u00E9s fonctionnelles valid\u00E9es et comptes ordonnateurs. Un graphique camembert permet de visualiser la r\u00E9partition par \u00E9tablissement.",
-      capabilities: [
-        "Vue multi-exercice (N et N-1) avec comparaison des indicateurs cl\u00E9s",
-        "Indicateur de validation de structure (pastille verte/orange) avec date et responsable",
-        "Onglets d\u00E9di\u00E9s : Lettres Budgets, UF Valides, Comptes Ordonnateurs",
-        "Graphique de r\u00E9partition par entit\u00E9 juridique (camembert interactif)",
-        "Widget Post-its int\u00E9gr\u00E9 avec tri par importance et par \u00E9metteur",
-        "Affichage du nombre total de comptes ordonnateurs par exercice",
-      ],
-      businessValue: "Permet aux d\u00E9cideurs et aux gestionnaires financiers de piloter la coh\u00E9rence de la structure budg\u00E9taire en temps r\u00E9el. La comparaison inter-exercices facilite le suivi de l\u2019\u00E9volution et la pr\u00E9paration des EPRD.",
-      screenshots: [{ file: "01-tableau-de-bord.jpg", caption: "Tableau de bord avec exercices 2025 et 2026, graphiques de r\u00E9partition par \u00E9tablissement" }],
-    },
-    {
-      title: "Post-its collaboratifs",
-      description: "Syst\u00E8me de messagerie interne l\u00E9g\u00E8re permettant aux utilisateurs d\u2019\u00E9changer des notes contextualis\u00E9es directement dans l\u2019espace de travail. Les post-its peuvent \u00EAtre class\u00E9s par importance (Urgent, Important, Normal) et filtr\u00E9s par \u00E9metteur.",
-      capabilities: [
-        "Cr\u00E9ation de post-its avec niveau de priorit\u00E9 (Urgent / Important / Normal)",
-        "Vue des post-its envoy\u00E9s et re\u00E7us",
-        "Tri par importance ou par \u00E9metteur",
-        "Compteurs synth\u00E9tiques sur le tableau de bord",
-      ],
-      businessValue: "Favorise la communication inter-\u00E9quipes sans quitter l\u2019application. Particuli\u00E8rement utile pour les \u00E9changes entre DAF, contr\u00F4le de gestion et cellule budg\u00E9taire lors des campagnes EPRD.",
-      screenshots: [{ file: "02-post-its.jpg", caption: "\u00C9cran Mes Post-its (envoy\u00E9s) avec bouton d\u2019ajout" }],
-    },
-    {
-      title: "Regroupement multi-entit\u00E9s juridiques (GHT)",
-      description: "Cet \u00E9cran permet de configurer et de g\u00E9rer le Groupement Hospitalier de Territoire (GHT) auquel l\u2019\u00E9tablissement est rattach\u00E9. Il centralise les informations r\u00E9glementaires (date d\u2019approbation ARS, SIRET, profil acheteur) et les param\u00E8tres de gestion mutualis\u00E9e des achats.",
-      capabilities: [
-        "Fiche GHT compl\u00E8te : d\u00E9nomination, date ARS, SIRET, URL profil acheteur",
-        "Configuration du module HA GHT : gestion centralis\u00E9e / non centralis\u00E9e / non mis en \u0153uvre",
-        "Num\u00E9rotation automatique fournisseurs et produits avec compteur param\u00E9trable",
-        "Liste des entit\u00E9s juridiques adh\u00E9rentes avec codes FINESS",
-        "Identification du site support GHT et du SIH Hexagone",
-        "Acc\u00E8s rapides vers les fiches d\u00E9taill\u00E9es de chaque EJ",
-      ],
-      businessValue: "R\u00E9pond aux obligations r\u00E9glementaires li\u00E9es \u00E0 la mutualisation des achats en GHT. Simplifie le param\u00E9trage initial et la gestion courante des regroupements multi-\u00E9tablissements.",
-      screenshots: [{ file: "03-ght.jpg", caption: "Formulaire GHT avec entit\u00E9s juridiques adh\u00E9rentes" }],
-    },
-    {
-      title: "Lettres budgets",
-      description: "Gestion centralis\u00E9e des lettres budgets de l\u2019\u00E9tablissement pour chaque exercice comptable. Chaque lettre budget (A \u00E0 M) correspond \u00E0 un p\u00E9rim\u00E8tre fonctionnel (Budget g\u00E9n\u00E9ral, EHPAD, IFSI, Long s\u00E9jour, Centre de sant\u00E9, GHT, etc.) avec sa nomenclature comptable associ\u00E9e (M21).",
-      capabilities: [
-        "Liste compl\u00E8te des lettres budgets par exercice avec libell\u00E9 et nomenclature",
-        "Cr\u00E9ation et param\u00E9trage de nouvelles lettres budgets",
-        "D\u00E9pliage hi\u00E9rarchique pour visualiser les d\u00E9tails de chaque lettre",
-        "S\u00E9lection d\u2019exercice (2025, 2026\u2026) avec statut de validation",
-        "D\u00E9tection d\u2019anomalies int\u00E9gr\u00E9e",
-        "Export des donn\u00E9es",
-      ],
-      businessValue: "Offre une vision structur\u00E9e de l\u2019ensemble des budgets annexes et du budget principal. Essentiel pour la pr\u00E9paration du Budget Initial, de l\u2019EPRD et du suivi infra-annuel dans le respect de la nomenclature M21.",
-      screenshots: [{ file: "04-lettres-budgets.jpg", caption: "Liste des lettres budgets A \u00E0 M avec nomenclature M21" }],
-    },
-    {
-      title: "D\u00E9coupages comptable",
-      description: "Module de gestion du d\u00E9coupage analytique de l\u2019\u00E9tablissement, organis\u00E9 en deux axes : les unit\u00E9s fonctionnelles (UF) et les p\u00F4les / niveaux de regroupements. Ce module permet de structurer l\u2019organigramme budg\u00E9taire de l\u2019h\u00F4pital.",
-      capabilities: [
-        "Onglet Unit\u00E9s Fonctionnelles : recherche multi-crit\u00E8res (UF, libell\u00E9, EJ, lettre budget GHT, dates)",
-        "Onglet P\u00F4les et Niveaux de Regroupements : gestion des natures et hi\u00E9rarchies",
-        "Ajout d\u2019UF, de natures et de regroupements",
-        "Filtrage par lettre budget GHT et entit\u00E9 juridique",
-        "Export au format CSV (tableur)",
-        "R\u00E9initialisation des filtres de recherche",
-      ],
-      businessValue: "Permet d\u2019aligner le d\u00E9coupage comptable avec l\u2019organisation m\u00E9dicale en p\u00F4les. Indispensable pour le suivi analytique par UF, la contractualisation interne et le reporting r\u00E9glementaire (RTC, SAE).",
-      screenshots: [
-        { file: "05a-decoupages-uf.jpg", caption: "Onglet Unit\u00E9s Fonctionnelles avec formulaire de recherche" },
-        { file: "05b-decoupages-poles.jpg", caption: "Onglet P\u00F4les et Niveaux de Regroupements" },
-      ],
-    },
-    {
-      title: "Plan comptable",
-      description: "Consultation et gestion du plan comptable de l\u2019\u00E9tablissement, d\u00E9coup\u00E9 en trois vues compl\u00E9mentaires : comptes de r\u00E9sultat, tableau de financement et comptes de tiers. L\u2019arborescence est organis\u00E9e par lettre budget et conforme \u00E0 la nomenclature M21.",
-      capabilities: [
-        "Onglet Comptes de R\u00E9sultat : arbre charges/produits par lettre budget d\u00E9pliable",
-        "Onglet Tableau de Financement : vue emplois/ressources par lettre budget",
-        "Onglet Comptes de Tiers : liste pagin\u00E9e (593 comptes) avec recherche par code ou libell\u00E9",
-        "Filtres avanc\u00E9s : niveau ordonnateur, nature, chapitre, nomenclature, ex\u00E9cutoire",
-        "Actions d\u2019\u00E9dition en ligne sur les comptes de tiers",
-        "Extraction CSV et fonctions replier/d\u00E9plier",
-        "Ajout de comptes de tiers",
-      ],
-      businessValue: "Donne aux \u00E9quipes financi\u00E8res une vision compl\u00E8te et navigable du plan comptable M21. Facilite la gestion quotidienne des imputations, la cr\u00E9ation de comptes de tiers et les contr\u00F4les de coh\u00E9rence.",
-      screenshots: [
-        { file: "06a-plan-comptable-resultat.jpg", caption: "Comptes de r\u00E9sultat avec arborescence par lettre budget" },
-        { file: "06b-plan-comptable-financement.jpg", caption: "Tableau de financement" },
-        { file: "06c-plan-comptable-tiers.jpg", caption: "Comptes de tiers avec recherche et pagination" },
-      ],
-    },
-    {
-      title: "Param\u00E9trages g\u00E9n\u00E9raux",
-      description: "Hub de param\u00E9trage centralis\u00E9 organis\u00E9 en trois cat\u00E9gories th\u00E9matiques : Structures (donn\u00E9es de r\u00E9f\u00E9rence), R\u00E9cup\u00E9ration (import de donn\u00E9es externes) et Historique (suivi des \u00E9volutions budg\u00E9taires).",
-      capabilities: [
-        "Structures : Banques, Nationalit\u00E9s, Communes, Codes postaux, Civilit\u00E9s \u2014 chaque rubrique avec formulaire de recherche, ajout et import fichier",
-        "R\u00E9cup\u00E9ration : Import de Comptes ordonnateurs, Historiques, Recettes diverses, GEF avec filtres (exercice, type, \u00E9tat d\u2019int\u00E9gration)",
-        "Historique : Masse financi\u00E8re et Consommations pour le suivi pluriannuel",
-        "Chaque sous-module poss\u00E8de son propre formulaire de recherche avanc\u00E9e",
-        "Fonctions d\u2019int\u00E9gration avec validation",
-        "Import par fichier pour chargement en masse",
-      ],
-      businessValue: "Centralise le param\u00E9trage de toutes les donn\u00E9es de r\u00E9f\u00E9rence n\u00E9cessaires au fonctionnement de l\u2019ERP. Les fonctions d\u2019import facilitent la reprise de donn\u00E9es et la mise \u00E0 jour en masse lors des changements r\u00E9glementaires.",
-      screenshots: [
-        { file: "07a-parametrages-hub.jpg", caption: "Hub de param\u00E9trage avec 3 colonnes th\u00E9matiques" },
-        { file: "07b-parametrages-banques.jpg", caption: "Sous-page Banques avec formulaire de recherche" },
-      ],
-    },
-    {
-      title: "R\u00E9f\u00E9rentiel GAP",
-      description: "Gestion des nomenclatures et r\u00E9f\u00E9rentiels utilis\u00E9s par le module GAP (Gestion Administrative du Patient). Trois niveaux sont distingu\u00E9s : livr\u00E9s (Dedalus), nationaux (r\u00E9glementaires) et t\u00E9l\u00E9charg\u00E9s (mis \u00E0 jour p\u00E9riodiquement).",
-      capabilities: [
-        "Onglet Livr\u00E9s (16 nomenclatures) : Codes proches, Lettres cl\u00E9 B2/DRE, Modes de PEC, Pi\u00E8ces justificatives, Protections civiles, Titres de praticiens, etc.",
-        "Onglet Nationaux (8 r\u00E9f\u00E9rentiels) : Activit\u00E9s socioprofessionnelles, Codes GIR, Disciplines M\u00E9dico-Tarifaires, Sp\u00E9cialit\u00E9s m\u00E9dicales, etc.",
-        "Onglet T\u00E9l\u00E9charg\u00E9s (10 r\u00E9f\u00E9rentiels versionn\u00E9s) : CCAM v82, NABM v93, LPP v800, GHS/GHT, UCD v715, COG, ICR, RIHN, ATU, Organismes SESAM-Vitale",
-        "Filtre de recherche par nom de nomenclature",
-        "Indicateur de version et date de mise \u00E0 jour pour chaque r\u00E9f\u00E9rentiel",
-      ],
-      businessValue: "Garantit la conformit\u00E9 r\u00E9glementaire en centralisant tous les r\u00E9f\u00E9rentiels n\u00E9cessaires \u00E0 la facturation, l\u2019identito-vigilance et la gestion du parcours patient. Le versionnement assure une tra\u00E7abilit\u00E9 compl\u00E8te des mises \u00E0 jour.",
-      screenshots: [
-        { file: "08a-referentiel-livres.jpg", caption: "R\u00E9f\u00E9rentiels livr\u00E9s (16 nomenclatures)" },
-        { file: "08b-referentiel-nationaux.jpg", caption: "R\u00E9f\u00E9rentiels nationaux" },
-        { file: "08c-referentiel-telecharges.jpg", caption: "R\u00E9f\u00E9rentiels t\u00E9l\u00E9charg\u00E9s avec versions" },
-      ],
-    },
-  ],
-};
-
-// ─── Load data ───
+// ─── Load and validate data ───
 const inputFile = getArg('--input');
-const data = inputFile ? JSON.parse(fs.readFileSync(inputFile, 'utf-8')) : DEFAULT_DATA;
+if (!inputFile) {
+  console.error('Error: --input argument is required.');
+  console.error('Usage: node generate-docx.js --input features.json --output document.docx [--screenshots /path/to/screenshots]');
+  console.error('');
+  console.error('A sample input file is available at: reference/default-structures-nomenclatures.json');
+  process.exit(1);
+}
+
+if (!fs.existsSync(inputFile)) {
+  console.error(`Error: Input file not found: ${inputFile}`);
+  process.exit(1);
+}
+
+let data;
+try {
+  data = JSON.parse(fs.readFileSync(inputFile, 'utf-8'));
+} catch (e) {
+  console.error(`Error: Failed to parse JSON from ${inputFile}: ${e.message}`);
+  process.exit(1);
+}
+
+const validationErrors = validateInput(data, inputFile);
+if (validationErrors.length > 0) {
+  console.error('Input validation failed:');
+  validationErrors.forEach(err => console.error(`  - ${err}`));
+  process.exit(1);
+}
+
+console.log(`Generating document for space: ${data.space}`);
+console.log(`Features: ${data.features.length}`);
 
 // ─── Build document ───
 const allFeatureChildren = [];

--- a/skills/hexagone-web-feature-extractor/scripts/package.json
+++ b/skills/hexagone-web-feature-extractor/scripts/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "hexagone-web-feature-extractor-scripts",
+  "version": "1.0.0",
+  "private": true,
+  "description": "Scripts for the hexagone-web-feature-extractor skill",
+  "scripts": {
+    "generate": "node generate-docx.js",
+    "bridge": "node screenshot-server.js"
+  },
+  "dependencies": {
+    "docx": "^9.0.0"
+  }
+}


### PR DESCRIPTION
## Résumé technique

### Contexte
Le skill hexagone-web-feature-extractor était couplé à un seul espace ("Structures / Nomenclatures") avec 130 lignes de données hardcodées dans le générateur DOCX, des sélecteurs CSS fragiles sans garde-fous, et aucune validation des entrées. Un document vide ou incomplet pouvait être produit sans aucun signal d'erreur.

### Approche retenue
Optimisation en profondeur du skill pour le rendre générique (tout espace Hexagone Web) et fiable (portes de vérification, validation d'entrée, gestion d'erreur explicite). Approche choisie : "généraliser d'abord, durcir ensuite" — les changements à plus haut ROI sont la suppression des données hardcodées et l'ajout de contrats d'entrée/sortie.

### Changements implémentés
| Fichier | Modification | Justification technique |
|---------|-------------|------------------------|
| `SKILL.md` | Réécriture complète en anglais, ajout `version: 1.0.0`, description raccourcie | Convention repo : SKILL.md en anglais, version obligatoire |
| `SKILL.md` | Section Configuration avec tous les magic numbers documentés | Rendre les valeurs calibrées explicites et ajustables |
| `SKILL.md` | Portes de vérification (Step 3.2, Step 5) | Empêcher les défaillances silencieuses (0 pages, screenshots manquants) |
| `SKILL.md` | Remplacement `querySelector('button')` par matching par texte | Éviter de cliquer sur le mauvais bouton si la page en a plusieurs |
| `SKILL.md` | Remplacement des waits hardcodés par des polling | Résilience aux temps de chargement variables |
| `SKILL.md` | Troubleshooting étendu de 5 à 11 entrées | Couvrir les modes de défaillance observés en pratique |
| `generate-docx.js` | Suppression de DEFAULT_DATA (~130 lignes), `--input` obligatoire | SRP : le générateur ne doit pas embarquer de données métier |
| `generate-docx.js` | Ajout validation d'entrée avec messages d'erreur clairs | Échouer explicitement sur JSON malformé au lieu de produire un doc corrompu |
| `reference/default-structures-nomenclatures.json` | Données extraites vers fichier de référence | Disponible comme exemple, séparé du code |
| `scripts/package.json` | Nouveau fichier avec dépendance `docx` explicite | Rendre les dépendances auto-descriptives |
| `docs/hexagone-web-feature-extractor.md` | Mise à jour pour refléter support tout-espace | Alignement doc/skill |

### Points d'attention pour la revue
- La validation JSON dans `generate-docx.js` couvre les types mais pas les valeurs sémantiques (ex: un titre vide `""` passe la validation)
- Les sélecteurs CSS fallback dans Step 3.2 sont des suggestions — ils nécessitent validation sur d'autres espaces Hexagone
- Le screenshot-server.js garde son parser multipart hand-rolled (phase 2 : remplacement par `busboy`)
- Les chemins `/home/claude/` restent les defaults — configurable via arguments CLI

### Tests
- Pas de suite de tests automatisée détectée dans ce repo
- Validation manuelle : structure JSON valide, SKILL.md frontmatter conforme

### Prochaines étapes
- [ ] Revue de code par l'équipe
- [ ] Phase 2 : remplacer le parser multipart par `busboy` dans screenshot-server.js
- [ ] Phase 2 : ajouter le support aspect-ratio dans le dimensionnement des images
- [ ] Phase 2 : externaliser le BRIDGE_HTML dans un fichier séparé
- [ ] Validation sur un espace Hexagone Web autre que Structures / Nomenclatures

---
_Implémentation générée automatiquement par IA_