### PR TITLE
feat(issue-review): add issue-review skill, rename gitlab-code-review to code-review

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,14 +28,14 @@ foundation-skills/
 
 ## Key Directories
 
-- `skills/` — Contains 36 skill directories, each with a `SKILL.md` file defining the skill's instructions
+- `skills/` — Contains 38 skill directories, each with a `SKILL.md` file defining the skill's instructions
 - `docs/` — Contains documentation files: one per skill plus general guides (healthcare parsers, installation, etc.)
 
 ## Skill Categories
 
 1. **Development skills:** coding-standards, backend-patterns, react-best-practices, vue-best-practices, frontend, web-design-guidelines, create-design-system-rules, mcp-builder, playwright-skill, postgres, security-review, tdd, testing-patterns, typescript-migration, git-guardrails, write-a-skill
 2. **Healthcare & legacy:** hpk-parser, hl7-pam-parser, hexagone-frontend, hexagone-swdoc, uniface-procscript
-3. **Issue/review management:** gitlab-code-review, gitlab-issue, github-issues, triage-issue
+3. **Issue/review management:** code-review, issue-review, gitlab-issue, github-issues, triage-issue
 4. **Document processing:** docx, pdf, pptx, xlsx, article-extractor
 5. **Collaboration:** meeting, fast-meeting, grill-me, ubiquitous-language
 6. **Utilities:** changelog-generator, docs

--- a/README.md
+++ b/README.md
@@ -57,7 +57,8 @@ npx skills add Dedalus-ERP-PAS/foundation-skills --skill backend-patterns --skil
 | [MCP builder](docs/mcp-builder.md)                                       | Guide pour créer des serveurs MCP (Model Context Protocol) en TypeScript ou Python               |
 | [Playwright skill](docs/playwright-skill.md)                             | Tests et automatisation web complète avec Playwright                                             |
 | [PostgreSQL](docs/postgres.md)                                           | Exécution de requêtes SQL en lecture seule sur PostgreSQL                                        |
-| [GitLab code review](docs/gitlab-code-review.md)                         | Revue de code des merge requests GitLab avec analyse qualité et sécurité                         |
+| [Code review](docs/code-review.md)                                       | Revue de code des merge requests GitLab avec analyse qualité et sécurité                         |
+| [Issue review](docs/issue-review.md)                                     | Revue autonome d'issues par personas IA avec publication du rapport sur l'issue                   |
 | [GitLab issue](docs/gitlab-issue.md)                                     | Création et gestion d'issues GitLab sur instance auto-hébergée                                   |
 | [GitHub issues](docs/github-issues.md)                                   | Création et gestion d'issues GitHub avec workflows structurés                                    |
 | [Security review](docs/security-review.md)                               | Audit de sécurité couvrant authentification, injection SQL, secrets et CSRF                      |
@@ -94,6 +95,7 @@ npx skills add Dedalus-ERP-PAS/foundation-skills --skill backend-patterns --skil
 
 - **Skills de développement** — Standards de code, patterns backend, best practices React et Vue.js
 - **Revue de code automatisée** — Analyse qualité, sécurité et performance des merge requests GitLab
+- **Revue d'issues par personas** — Analyse multi-angle de la faisabilité, complétude et risques avant implémentation
 - **Parseurs de messages de santé** — Interprétation des formats HPK et HL7 PAM utilisés en milieu hospitalier
 - **Gestion d'issues** — Création et suivi d'issues GitHub et GitLab avec contexte enrichi
 - **Manipulation de documents** — Création et édition de fichiers Word, Excel, PowerPoint et PDF
@@ -144,7 +146,8 @@ Le développeur installe les skills via la commande `npx skills add`. Les fichie
 | **create-design-system-rules**     | Règles de design system pour workflows Figma-to-code                                                   | [create-design-system-rules.md](docs/create-design-system-rules.md)         |
 | **frontend**                       | Règles de développement frontend natif — respect du framework et du design system                      | [frontend.md](docs/frontend.md)                                             |
 | **github-issues**                  | Gestion complète des issues GitHub : création, recherche, mise à jour et commentaires                  | [github-issues.md](docs/github-issues.md)                                   |
-| **gitlab-code-review**             | Revue de code des merge requests GitLab : qualité, sécurité, performance                               | [gitlab-code-review.md](docs/gitlab-code-review.md)                         |
+| **code-review**                    | Revue de code des merge requests GitLab : qualité, sécurité, performance                               | [code-review.md](docs/code-review.md)                                       |
+| **issue-review**                   | Revue autonome d'issues par personas IA : faisabilité, complétude, risques et publication sur l'issue  | [issue-review.md](docs/issue-review.md)                                     |
 | **fast-meeting**                   | Réunion rapide autonome : analyse, décision, implémentation et création de MR/PR sans intervention     | [fast-meeting.md](docs/fast-meeting.md)                                     |
 | **meeting**                        | Réunion simulée avec personas pour analyser un sujet et décider avant d'implémenter                    | [meeting.md](docs/meeting.md)                                               |
 | **gitlab-issue**                   | Gestion des issues GitLab sur instances auto-hébergées                                                 | [gitlab-issue.md](docs/gitlab-issue.md)                                     |

--- a/docs/README.md
+++ b/docs/README.md
@@ -2,12 +2,12 @@
 
 Index de la documentation disponible pour les Foundation Skills.
 
-## Guides generaux
+## Guides généraux
 
-| Document                                   | Description                                                                               |
-| ------------------------------------------ | ----------------------------------------------------------------------------------------- |
-| [comment-utiliser.md](comment-utiliser.md) | **Guide complet** - Installation, utilisation avec differents agents, exemples, depannage |
-| [coding-standards.md](coding-standards.md) | Standards de code universels pour TypeScript/JavaScript                                   |
+| Document                                   | Description                                                                                |
+| ------------------------------------------ | ------------------------------------------------------------------------------------------ |
+| [comment-utiliser.md](comment-utiliser.md) | **Guide complet** — Installation, utilisation avec différents agents, exemples, dépannage |
+| [coding-standards.md](coding-standards.md) | Standards de code universels pour TypeScript/JavaScript                                    |
 
 ## Documentation par skill
 
@@ -16,27 +16,27 @@ Index de la documentation disponible pour les Foundation Skills.
 | Skill                                   | Documentation                                                  |
 | --------------------------------------- | -------------------------------------------------------------- |
 | [backend-patterns](backend-patterns.md) | Patterns d'architecture backend, API design, DB, caching, auth |
-| [postgres](postgres.md)                 | Requetes SQL lecture seule sur PostgreSQL                      |
+| [postgres](postgres.md)                 | Requêtes SQL lecture seule sur PostgreSQL                      |
 
 ### Frontend
 
-| Skill                                             | Documentation                          |
-| ------------------------------------------------- | -------------------------------------- |
-| [react-best-practices](react-best-practices.md)   | Guidelines performance React/Next.js   |
-| [vue-best-practices](vue-best-practices.md)       | Best practices Vue.js 3/Nuxt           |
-| [frontend](frontend.md)                           | Regles de developpement frontend natif |
-| [web-design-guidelines](web-design-guidelines.md) | Audit UI, accessibilite et UX          |
+| Skill                                             | Documentation                           |
+| ------------------------------------------------- | --------------------------------------- |
+| [react-best-practices](react-best-practices.md)   | Guidelines performance React/Next.js    |
+| [vue-best-practices](vue-best-practices.md)       | Best practices Vue.js 3/Nuxt            |
+| [frontend](frontend.md)                           | Règles de développement frontend natif  |
+| [web-design-guidelines](web-design-guidelines.md) | Audit UI, accessibilité et UX           |
 
-### Securite & Qualite
+### Sécurité & Qualité
 
-| Skill                                           | Documentation                                 |
-| ----------------------------------------------- | --------------------------------------------- |
-| [security-review](security-review.md)           | Audit de securite et OWASP Top 10             |
-| [coding-standards](coding-standards.md)         | Standards de code                             |
-| [tdd](tdd.md)                                   | Developpement pilote par les tests (TDD)      |
-| [testing-patterns](testing-patterns.md)         | Patterns de test : unitaire, integration, E2E |
-| [typescript-migration](typescript-migration.md) | Migration incrementale JS vers TypeScript     |
-| [git-guardrails](git-guardrails.md)             | Garde-fous Git pour des commits propres       |
+| Skill                                           | Documentation                                  |
+| ----------------------------------------------- | ---------------------------------------------- |
+| [security-review](security-review.md)           | Audit de sécurité et OWASP Top 10              |
+| [coding-standards](coding-standards.md)         | Standards de code                              |
+| [tdd](tdd.md)                                   | Développement piloté par les tests (TDD)       |
+| [testing-patterns](testing-patterns.md)         | Patterns de test : unitaire, intégration, E2E  |
+| [typescript-migration](typescript-migration.md) | Migration incrémentale JS vers TypeScript      |
+| [git-guardrails](git-guardrails.md)             | Garde-fous Git pour des commits propres        |
 
 ### Automatisation & Tests
 
@@ -46,12 +46,12 @@ Index de la documentation disponible pour les Foundation Skills.
 
 ### Documents Office
 
-| Skill           | Documentation                    |
-| --------------- | -------------------------------- |
-| [docx](docx.md) | Documents Word (.docx)           |
-| [pptx](pptx.md) | Presentations PowerPoint (.pptx) |
-| [xlsx](xlsx.md) | Fichiers Excel avec formules     |
-| [pdf](pdf.md)   | Manipulation de PDF              |
+| Skill            | Documentation                     |
+| ---------------- | --------------------------------- |
+| [docx](docx.md)  | Documents Word (.docx)            |
+| [pptx](pptx.md)  | Présentations PowerPoint (.pptx)  |
+| [xlsx](xlsx.md)  | Fichiers Excel avec formules      |
+| [pdf](pdf.md)    | Manipulation de PDF               |
 
 ### Gestion de projet
 
@@ -59,36 +59,37 @@ Index de la documentation disponible pour les Foundation Skills.
 | --------------------------------------------- | ------------------------------------------------------------- |
 | [github-issues](github-issues.md)             | Gestion des issues GitHub                                     |
 | [gitlab-issue](gitlab-issue.md)               | Gestion des issues GitLab                                     |
-| [gitlab-code-review](gitlab-code-review.md)   | Code review GitLab                                            |
-| [changelog-generator](changelog-generator.md) | Generation de changelogs                                      |
+| [code-review](code-review.md)                 | Code review des merge requests                                |
+| [issue-review](issue-review.md)               | Revue autonome d'issues par personas IA                       |
+| [changelog-generator](changelog-generator.md) | Génération de changelogs                                      |
 | [grill-me](grill-me.md)                       | Interview approfondie pour validation de plans et conceptions |
 | [triage-issue](triage-issue.md)               | Triage de bugs avec plan de fix TDD                           |
-| [meeting](meeting.md)                         | Reunion simulee avec personas experts                         |
-| [fast-meeting](fast-meeting.md)               | Reunion autonome rapide avec decision et MR/PR                |
+| [meeting](meeting.md)                         | Réunion simulée avec personas experts                         |
+| [fast-meeting](fast-meeting.md)               | Réunion autonome rapide avec décision et MR/PR                |
 
-### Hexagone / Domaine sante
+### Hexagone / Domaine santé
 
 | Skill                                                               | Documentation                                                          |
 | ------------------------------------------------------------------- | ---------------------------------------------------------------------- |
 | [hexagone-swdoc](hexagone-swdoc.md)                                 | Documentation des web services Hexagone (endpoints, formats, contrats) |
 | [hexagone-frontend](hexagone-frontend.md)                           | Documentation des composants frontend Hexagone (@his/hexa-components)  |
-| [hexagone-web-feature-extractor](hexagone-web-feature-extractor.md) | Exploration et capture d'un espace Hexagone Web en document Word PO    |
-| [hpk-parser](hpk-parser.md)                                         | Parsing des messages HPK proprietaires                                 |
+| [hexagone-web-feature-extractor](hexagone-web-feature-extractor.md) | Exploration et capture d'un espace Hexagone Web en document Markdown PO |
+| [hpk-parser](hpk-parser.md)                                         | Parsing des messages HPK propriétaires                                 |
 | [hl7-pam-parser](hl7-pam-parser.md)                                 | Parsing des messages HL7 v2.5 IHE PAM                                  |
-| [uniface-procscript](uniface-procscript.md)                         | Reference ProcScript pour Uniface 9.7                                  |
+| [uniface-procscript](uniface-procscript.md)                         | Référence ProcScript pour Uniface 9.7                                  |
 
-### Outils specialises
+### Outils spécialisés
 
 | Skill                                                       | Documentation                                     |
 | ----------------------------------------------------------- | ------------------------------------------------- |
-| [mcp-builder](mcp-builder.md)                               | Creation de serveurs MCP                          |
+| [mcp-builder](mcp-builder.md)                               | Création de serveurs MCP                          |
 | [article-extractor](article-extractor.md)                   | Extraction d'articles web                         |
-| [create-design-system-rules](create-design-system-rules.md) | Generation de regles de design system             |
-| [docs](docs.md)                                             | Generation de README et documentation projet      |
-| [write-a-skill](write-a-skill.md)                           | Guide pour creer un nouveau skill                 |
+| [create-design-system-rules](create-design-system-rules.md) | Génération de règles de design system             |
+| [docs](docs.md)                                             | Génération de README et documentation projet      |
+| [write-a-skill](write-a-skill.md)                           | Guide pour créer un nouveau skill                 |
 | [ubiquitous-language](ubiquitous-language.md)               | Extraction de glossaire DDD (langage ubiquitaire) |
 
-## Demarrage rapide
+## Démarrage rapide
 
 ### 1. Installation
 
@@ -96,7 +97,7 @@ Index de la documentation disponible pour les Foundation Skills.
 # Tous les skills
 npx skills add Dedalus-ERP-PAS/foundation-skills -g -y
 
-# Skill specifique
+# Skill spécifique
 npx skills add Dedalus-ERP-PAS/foundation-skills --skill backend-patterns -g -y
 ```
 
@@ -104,7 +105,7 @@ npx skills add Dedalus-ERP-PAS/foundation-skills --skill backend-patterns -g -y
 
 ```
 # Dans GitHub Copilot, Claude, Cursor ou Windsurf
-@workspace avec backend-patterns, cree une API REST pour les users
+@workspace avec backend-patterns, crée une API REST pour les users
 ```
 
 ### 3. Consulter le guide complet
@@ -114,8 +115,8 @@ Voir le [guide complet d'utilisation](comment-utiliser.md).
 ## Bonnes pratiques
 
 - **Mentionner explicitement le skill** dans vos prompts
-- **Combiner plusieurs skills** pour des taches complexes
-- **Commencer simple** puis iterer
+- **Combiner plusieurs skills** pour des tâches complexes
+- **Commencer simple** puis itérer
 - **Consulter la doc** du skill avant utilisation
 
 ## Support

--- a/docs/code-review.md
+++ b/docs/code-review.md
@@ -24,7 +24,7 @@ Montre-moi les MR ouvertes à reviewer
 
 ## Prérequis
 
-- Serveur **MCP** (Model Context Protocol) GitLab configuré (`gitlab-mcp`)
+- CLI **glab** configuré et authentifié auprès de l'instance GitLab
 - Accès à l'instance GitLab auto-hébergée Dedalus : https://gitlab-erp-pas.dedalus.lan
 - Identifiants et permissions appropriés sur les projets concernés
 
@@ -106,9 +106,9 @@ Assistant :
 ## Démarrage rapide
 
 ```bash
-npx skills add Dedalus-ERP-PAS/foundation-skills --skill gitlab-code-review -g -y
+npx skills add Dedalus-ERP-PAS/foundation-skills --skill code-review -g -y
 ```
 
 ## Ressources
 
-- [SKILL.md complet](../skills/gitlab-code-review/SKILL.md) — Guide détaillé
+- [SKILL.md complet](../skills/code-review/SKILL.md) — Guide détaillé

--- a/docs/frontend.md
+++ b/docs/frontend.md
@@ -100,9 +100,7 @@ Le skill applique des règles strictes selon le contexte détecté.
 
 - **vue-best-practices** / **react-best-practices** — Patrons spécifiques au framework
 - **create-design-system-rules** — Pour les projets sans design system établi
-- **web-design-guidelines** — Pour auditer l'accessibilité et la qualité UI
-- **react-best-practices** / **vue-best-practices** — Patterns de code pour les frameworks
-- **web-design-guidelines** — Audit et revue d'interfaces existantes
+- **web-design-guidelines** — Audit accessibilité et qualité UI
 
 ## Ressources
 

--- a/docs/github-issues.md
+++ b/docs/github-issues.md
@@ -54,7 +54,7 @@ Trouve les bugs créés cette semaine
 
 ## Prérequis
 
-- Serveur MCP (Model Context Protocol) GitHub configuré (`github-mcp`)
+- CLI **gh** (GitHub CLI) installé et authentifié
 - Accès au repository GitHub concerné
 
 ## Types d'issues

--- a/docs/gitlab-issue.md
+++ b/docs/gitlab-issue.md
@@ -50,7 +50,7 @@ Ajoute le label "priority::high" à l'issue #45
 
 ## Prérequis
 
-- Serveur MCP (Model Context Protocol) GitLab configuré (`gitlab-mcp`)
+- CLI **glab** configuré et authentifié auprès de l'instance GitLab
 - Accès à l'instance GitLab auto-hébergée : https://gitlab-erp-pas.dedalus.lan
 - Identifiants et permissions appropriés sur les projets GitLab concernés
 

--- a/docs/healthcare-parsers-guide.md
+++ b/docs/healthcare-parsers-guide.md
@@ -1,44 +1,44 @@
 # Guide des parsers healthcare
 
-Guide pour utiliser les skills **hpk-parser** et **hl7-pam-parser** afin de parser les messages de sante.
+Guide pour utiliser les skills **hpk-parser** et **hl7-pam-parser** afin de parser les messages de santé.
 
 ## Vue d'ensemble
 
-Ces deux skills parsent et expliquent les messages utilises dans les SIH (Systemes d'Information Hospitaliers) francais :
+Ces deux skills parsent et expliquent les messages utilisés dans les SIH (Systèmes d'Information Hospitaliers) français :
 
-- **hpk-parser** : format proprietaire HPK (Healthcare Protocol Kernel), delimiteur pipe (`|`)
+- **hpk-parser** : format propriétaire HPK (Healthcare Protocol Kernel), délimiteur pipe (`|`)
 - **hl7-pam-parser** : standard international HL7 v2.5 IHE PAM (Patient Administration Management)
 
 ### Quel skill utiliser ?
 
 | Situation | Skill |
 |-----------|-------|
-| Message avec delimiteurs `|` et champs fixes | `hpk-parser` |
-| Message commencant par `MSH|^~\&` | `hl7-pam-parser` |
-| Format proprietaire francais (HPK/GEF) | `hpk-parser` |
+| Message avec délimiteurs `|` et champs fixes | `hpk-parser` |
+| Message commençant par `MSH|^~\&` | `hl7-pam-parser` |
+| Format propriétaire français (HPK/GEF) | `hpk-parser` |
 | Standard HL7 v2.5 international | `hl7-pam-parser` |
 | Message inconnu | Les deux (l'agent choisira) |
 
 ## HPK Parser
 
-### Types de messages supportes
+### Types de messages supportés
 
-#### Identite (ID|*)
+#### Identité (ID|*)
 
 | Code | Description |
 |------|-------------|
-| **ID\|M1** | Identite patient (demographie) |
-| **ID\|MT** | Medecin traitant |
-| **ID\|CE** | Consentement eclaire |
+| **ID\|M1** | Identité patient (démographie) |
+| **ID\|MT** | Médecin traitant |
+| **ID\|CE** | Consentement éclairé |
 
 #### Mouvements (MV|*)
 
 | Code | Description |
 |------|-------------|
-| **MV\|M2** | Admission hospitaliere |
+| **MV\|M2** | Admission hospitalière |
 | **MV\|M3** | Changement de statut |
-| **MV\|M6** | Transfert inter-unites |
-| **MV\|M8** | Sortie d'unite |
+| **MV\|M6** | Transfert inter-unités |
+| **MV\|M8** | Sortie d'unité |
 | **MV\|M9** | Sortie d'hospitalisation |
 | **MV\|B1** | Mouvement box urgences |
 | **MV\|MT** | Mouvement temporaire |
@@ -56,19 +56,19 @@ Prompt : "Parse ce message HPK :
 ID|M1|C|HEXAGONE|20260122120000|USER001|PAT12345|DUPONT|JEAN|19750315|M|..."
 ```
 
-Le skill retourne le type de message, les champs extraits et le contexte metier.
+Le skill retourne le type de message, les champs extraits et le contexte métier.
 
 ## HL7 PAM Parser
 
-### Types de messages supportes (ADT)
+### Types de messages supportés (ADT)
 
 | Code | Description |
 |------|-------------|
 | **ADT^A01** | Admission |
 | **ADT^A02** | Transfert patient |
 | **ADT^A03** | Sortie d'hospitalisation |
-| **ADT^A04** | Pre-admission |
-| **ADT^A08** | Mise a jour demographie |
+| **ADT^A04** | Pré-admission |
+| **ADT^A08** | Mise à jour démographie |
 | **ADT^A11** | Annulation admission |
 | **ADT^A12** | Annulation transfert |
 | **ADT^A13** | Annulation sortie |
@@ -83,28 +83,28 @@ PID|1||PAT12345^^^CHU_PARIS^PI||DUPONT^JEAN||19750315|M
 PV1|1|I|CHU_PARIS^CARDIO^LIT_001||||PR_MARTIN^MARTIN^SOPHIE"
 ```
 
-Le skill retourne les segments MSH, EVN, PID, PV1 detailles et la conformite IHE PAM 2.10.
+Le skill retourne les segments MSH, EVN, PID, PV1 détaillés et la conformité IHE PAM 2.10.
 
 ## Cas d'usage courants
 
 ### Comprendre un message inconnu
 
 ```
-J'ai recu ce message, peux-tu m'expliquer ce que c'est ?
+J'ai reçu ce message, peux-tu m'expliquer ce que c'est ?
 ID|M1|C|HEXAGONE|20260122120000|...
 ```
 
 L'agent identifie automatiquement le format et utilise le bon skill.
 
-### Deboguer un probleme d'integration
+### Déboguer un problème d'intégration
 
 ```
-Notre interface recoit ce message HL7 mais l'admission echoue.
-Peux-tu identifier le probleme ?
+Notre interface reçoit ce message HL7 mais l'admission échoue.
+Peux-tu identifier le problème ?
 MSH|^~\&|APP|FAC|...
 ```
 
-L'agent parse, valide contre IHE PAM 2.10, et suggere les corrections.
+L'agent parse, valide contre IHE PAM 2.10, et suggère les corrections.
 
 ### Transformation HPK vers HL7
 
@@ -112,31 +112,31 @@ L'agent parse, valide contre IHE PAM 2.10, et suggere les corrections.
 J'ai ce message HPK d'admission :
 MV|M2|C|HEXAGONE|20260122140000|USER001|PAT12345|VIS001|...
 
-Genere le message HL7 IHE PAM equivalent (ADT^A01)
+Génère le message HL7 IHE PAM équivalent (ADT^A01)
 ```
 
 L'agent mappe les champs HPK vers les segments HL7.
 
 ## Bonnes pratiques
 
-- **Specifier le skill** : "Utilise hpk-parser pour ce message HPK"
+- **Spécifier le skill** : "Utilise hpk-parser pour ce message HPK"
 - **Fournir le message complet** : ne pas tronquer les champs
 - **Demander la validation** : "Parse et valide contre IHE PAM 2.10"
-- **Documenter le contexte** : preciser le systeme source et l'objectif
+- **Documenter le contexte** : préciser le système source et l'objectif
 
-## Depannage
+## Dépannage
 
-| Probleme | Solution |
+| Problème | Solution |
 |----------|----------|
-| Message non reconnu | Specifier le skill explicitement dans le prompt |
+| Message non reconnu | Spécifier le skill explicitement dans le prompt |
 | Parsing incomplet | Demander une analyse champ par champ |
-| Validation echouee a tort | Demander les references IHE PAM 2.10 exactes |
+| Validation échouée à tort | Demander les références IHE PAM 2.10 exactes |
 | Dates incorrectes | HPK : `YYYYMMDDHHmmss` (14 car.), HL7 : `YYYYMMDDHHmmss` ou `YYYYMMDD` |
-| Delimiteurs mal interpretes | HPK : `|` uniquement. HL7 : `|` (champs), `^` (composants), `~` (repetitions) |
+| Délimiteurs mal interprétés | HPK : `|` uniquement. HL7 : `|` (champs), `^` (composants), `~` (répétitions) |
 
-## References
+## Références
 
 - [hpk-parser](hpk-parser.md) -- Documentation du skill HPK
 - [hl7-pam-parser](hl7-pam-parser.md) -- Documentation du skill HL7 PAM
-- [IHE PAM 2.10](https://github.com/Interop-Sante/ihe.iti.pam.fr) -- Specification officielle
+- [IHE PAM 2.10](https://github.com/Interop-Sante/ihe.iti.pam.fr) -- Spécification officielle
 - [HL7 v2.5](http://www.hl7.eu/HL7v2x/v25/std25/ch02.html) -- Standard HL7

--- a/docs/hl7-pam-parser.md
+++ b/docs/hl7-pam-parser.md
@@ -1,36 +1,36 @@
 # hl7-pam-parser
 
-Parsing et explication des messages HL7 v2.5 IHE PAM (Patient Administration Management). Standard d'interoperabilite pour l'administration des patients.
+Parsing et explication des messages HL7 v2.5 IHE PAM (Patient Administration Management). Standard d'interopérabilité pour l'administration des patients.
 
 ## Quand utiliser ce skill
 
 - Comprendre le contenu d'un message HL7 ADT
-- Deboguer des problemes d'interoperabilite HL7
+- Déboguer des problèmes d'interopérabilité HL7
 - Valider un message selon IHE PAM 2.10
 - Documenter des exemples de messages HL7
 
 ## Ce que fait le skill
 
 - **Parse** les messages HL7 ADT et identifie le type
-- **Extrait** les segments (MSH, EVN, PID, PV1, PV2) avec libelles
+- **Extrait** les segments (MSH, EVN, PID, PV1, PV2) avec libellés
 - **Valide** la structure selon IHE PAM 2.10
-- **Explique** le message en langage comprehensible
-- **Documente** les regles metier et la conformite
+- **Explique** le message en langage compréhensible
+- **Documente** les règles métier et la conformité
 
-## Types de messages supportes
+## Types de messages supportés
 
 ### Messages ADT (Admission, Transfert, Sortie)
 
 | Code | Description |
 |------|-------------|
-| **ADT^A01** | Admission (entree du patient) |
-| **ADT^A02** | Transfert (changement d'unite/chambre) |
+| **ADT^A01** | Admission (entrée du patient) |
+| **ADT^A02** | Transfert (changement d'unité/chambre) |
 | **ADT^A03** | Sortie d'hospitalisation |
-| **ADT^A04** | Pre-admission / ambulatoire |
-| **ADT^A05** | Pre-admission d'un patient |
+| **ADT^A04** | Pré-admission / ambulatoire |
+| **ADT^A05** | Pré-admission d'un patient |
 | **ADT^A06** | Passage ambulatoire vers hospitalisation |
 | **ADT^A07** | Passage hospitalisation vers ambulatoire |
-| **ADT^A08** | Mise a jour des informations patient |
+| **ADT^A08** | Mise à jour des informations patient |
 | **ADT^A11** | Annulation d'admission |
 | **ADT^A12** | Annulation de transfert |
 | **ADT^A13** | Annulation de sortie |
@@ -39,7 +39,7 @@ Parsing et explication des messages HL7 v2.5 IHE PAM (Patient Administration Man
 
 ## Exemple d'utilisation
 
-**Message en entree** :
+**Message en entrée** :
 ```
 MSH|^~\&|HEXAFLUX|CHU_PARIS|TARGET|DEST|20260122140000||ADT^A01^ADT_A01|MSG001|P|2.5
 EVN|A01|20260122140000|||USER001
@@ -47,57 +47,57 @@ PID|1||PAT12345^^^CHU_PARIS^PI||DUPONT^JEAN^^M.||19750315|M|||15 RUE DE LA PAIX^
 PV1|1|I|CHU_PARIS^CARDIO^LIT_001^CHU_PARIS||||PR_MARTIN^MARTIN^SOPHIE|||CARDIO||||||||||VIS20260122001|||||||||||||||||||||||||20260122140000
 ```
 
-**Resultat** :
+**Résultat** :
 ```
 Type : ADT^A01 (Notification d'admission)
-Evenement : A01 -- Admission en hospitalisation
-Patient : JEAN DUPONT, ne le 15/03/1975, Masculin (ID : PAT12345)
-Sejour : VIS20260122001
+Événement : A01 -- Admission en hospitalisation
+Patient : JEAN DUPONT, né le 15/03/1975, Masculin (ID : PAT12345)
+Séjour : VIS20260122001
 Admission : 22/01/2026 14:00:00
 Localisation : CHU_PARIS, Cardiologie, Lit LIT_001
-Medecin : Dr. MARTIN SOPHIE
-Classe patient : Hospitalise
+Médecin : Dr. MARTIN SOPHIE
+Classe patient : Hospitalisé
 ```
 
 ## Structure d'un message HL7
 
-Delimiteurs HL7 v2.5 :
+Délimiteurs HL7 v2.5 :
 
-| Caractere | Role |
+| Caractère | Rôle |
 |-----------|------|
-| `\|` | Separateur de champs |
-| `^` | Separateur de composants |
-| `~` | Separateur de repetitions |
-| `\` | Caractere d'echappement |
-| `&` | Separateur de sous-composants |
+| `\|` | Séparateur de champs |
+| `^` | Séparateur de composants |
+| `~` | Séparateur de répétitions |
+| `\` | Caractère d'échappement |
+| `&` | Séparateur de sous-composants |
 
 ## Segments principaux
 
-| Segment | Role | Obligatoire |
+| Segment | Rôle | Obligatoire |
 |---------|------|-------------|
-| **MSH** | En-tete du message (routage, metadonnees) | Oui |
-| **EVN** | Type d'evenement (code, horodatage) | Oui |
-| **PID** | Identification patient (identite, demographie) | Oui |
-| **PV1** | Visite patient (classe, localisation, medecin) | Oui |
-| **PV2** | Informations complementaires de visite | Non |
+| **MSH** | En-tête du message (routage, métadonnées) | Oui |
+| **EVN** | Type d'événement (code, horodatage) | Oui |
+| **PID** | Identification patient (identité, démographie) | Oui |
+| **PV1** | Visite patient (classe, localisation, médecin) | Oui |
+| **PV2** | Informations complémentaires de visite | Non |
 
-## Conformite IHE PAM 2.10
+## Conformité IHE PAM 2.10
 
 Le parser valide les champs obligatoires :
 
-- **MSH** : application emettrice, etablissement, date, type, ID controle, version
-- **EVN** : code evenement, date d'enregistrement
+- **MSH** : application émettrice, établissement, date, type, ID contrôle, version
+- **EVN** : code événement, date d'enregistrement
 - **PID** : ID patient, nom, date de naissance, sexe
-- **PV1** : classe patient, localisation, numero de sejour
+- **PV1** : classe patient, localisation, numéro de séjour
 
-## References
+## Références
 
-- [Specification IHE PAM 2.10](https://github.com/Interop-Sante/ihe.iti.pam.fr) (francais)
+- [Spécification IHE PAM 2.10](https://github.com/Interop-Sante/ihe.iti.pam.fr) (français)
 - [Profil IHE PAM](https://profiles.ihe.net/ITI/TF/Volume1/ch-14.html) (international)
 - [Standard HL7 v2.5](http://www.hl7.eu/HL7v2x/v25/std25/ch02.html)
-- [SKILL.md](../skills/hl7-pam-parser/SKILL.md) -- structures detaillees des segments
+- [SKILL.md](../skills/hl7-pam-parser/SKILL.md) -- structures détaillées des segments
 
 ## Skills connexes
 
-- **hpk-parser** -- messages HPK (format proprietaire francais mappe vers HL7)
+- **hpk-parser** -- messages HPK (format propriétaire français mappé vers HL7)
 - **hexagone-swdoc** -- web services Hexagone

--- a/docs/hpk-adt-message.md
+++ b/docs/hpk-adt-message.md
@@ -1,1511 +1,8 @@
-# Specification des messages HPK ADT - Service Echange
+# Spécification des messages HPK ADT - Service Échange
 
-Specification de reference des messages HPK ADT (Admission, Discharge, Transfer) du Service Echange Hexagone. Ce document decrit les structures de donnees pour les messages d'identite (ID), mouvements (MV), couverture (CV) et autres types HPK.
+Spécification de référence des messages HPK ADT (Admission, Discharge, Transfer) du Service Échange Hexagone. Ce document décrit les structures de données pour les messages d'identité (ID), mouvements (MV), couverture (CV) et autres types HPK.
 
-> **Note technique** : ce document est une conversion automatique de la specification Word officielle. Il sert de reference pour le skill `hpk-parser`.
-
-## Maitrise du document
-
-| | |
-|---|---|
-| **Redacteur** | P. LAUNAY -- Responsable Unite de developpement |
-| **Date de creation** | 27/08/1999 |
-| **Derniere mise a jour** | 22/01/2026 |
-
-## Historique des versions
-
-+------+---+------+----------------------------------------+------+------+
-| Date |   | Op   |                                        | Révi | D    |
-|      |   | érat |                                        | sion | iffu |
-|      |   | ions |                                        |      | sion |
-|      |   | et   |                                        |      |      |
-|      |   | comm |                                        |      |      |
-|      |   | enta |                                        |      |      |
-|      |   | ires |                                        |      |      |
-+------+---+------+----------------------------------------+------+------+
-| 1.0  | 2 |      | P. Launay: Création                    |      | ![]  |
-|      | 7 |      |                                        |      | (ver |
-|      | / |      |                                        |      | topa |
-|      | 0 |      |                                        |      | l_d5 |
-|      | 8 |      |                                        |      | b45b |
-|      | / |      |                                        |      | 6900 |
-|      | 9 |      |                                        |      | c449 |
-|      | 9 |      |                                        |      | bd9c |
-|      |   |      |                                        |      | d55a |
-|      |   |      |                                        |      | 0f4a |
-|      |   |      |                                        |      | cdb4 |
-|      |   |      |                                        |      | a7/m |
-|      |   |      |                                        |      | edia |
-|      |   |      |                                        |      | /ima |
-|      |   |      |                                        |      | ge3. |
-|      |   |      |                                        |      | png) |
-+------+---+------+----------------------------------------+------+------+
-| 1.1  | 1 |      | C. Madrid: Modification                | ![]  | ![]  |
-|      | 5 |      |                                        | (ver | (ver |
-|      | / |      |                                        | topa | topa |
-|      | 0 |      |                                        | l_d5 | l_d5 |
-|      | 9 |      |                                        | b45b | b45b |
-|      | / |      |                                        | 6900 | 6900 |
-|      | 9 |      |                                        | c449 | c449 |
-|      | 9 |      |                                        | bd9c | bd9c |
-|      |   |      |                                        | d55a | d55a |
-|      |   |      |                                        | 0f4a | 0f4a |
-|      |   |      |                                        | cdb4 | cdb4 |
-|      |   |      |                                        | a7/m | a7/m |
-|      |   |      |                                        | edia | edia |
-|      |   |      |                                        | /ima | /ima |
-|      |   |      |                                        | ge4. | ge3. |
-|      |   |      |                                        | png) | png) |
-+------+---+------+----------------------------------------+------+------+
-| 2.1  | 2 |      | P. Launay: Prise en compte des         | ![]  | ![]  |
-|      | 7 |      | messages utilisateurs                  | (ver | (ver |
-|      | / |      |                                        | topa | topa |
-|      | 0 |      |                                        | l_d5 | l_d5 |
-|      | 9 |      |                                        | b45b | b45b |
-|      | / |      |                                        | 6900 | 6900 |
-|      | 9 |      |                                        | c449 | c449 |
-|      | 9 |      |                                        | bd9c | bd9c |
-|      |   |      |                                        | d55a | d55a |
-|      |   |      |                                        | 0f4a | 0f4a |
-|      |   |      |                                        | cdb4 | cdb4 |
-|      |   |      |                                        | a7/m | a7/m |
-|      |   |      |                                        | edia | edia |
-|      |   |      |                                        | /ima | /ima |
-|      |   |      |                                        | ge4. | ge3. |
-|      |   |      |                                        | png) | png) |
-+------+---+------+----------------------------------------+------+------+
-| 2.2  | 2 |      | C. Madrid: Modification (individu)     | ![]  | ![]  |
-|      | 7 |      |                                        | (ver | (ver |
-|      | / |      |                                        | topa | topa |
-|      | 0 |      |                                        | l_d5 | l_d5 |
-|      | 9 |      |                                        | b45b | b45b |
-|      | / |      |                                        | 6900 | 6900 |
-|      | 9 |      |                                        | c449 | c449 |
-|      | 9 |      |                                        | bd9c | bd9c |
-|      |   |      |                                        | d55a | d55a |
-|      |   |      |                                        | 0f4a | 0f4a |
-|      |   |      |                                        | cdb4 | cdb4 |
-|      |   |      |                                        | a7/m | a7/m |
-|      |   |      |                                        | edia | edia |
-|      |   |      |                                        | /ima | /ima |
-|      |   |      |                                        | ge4. | ge3. |
-|      |   |      |                                        | png) | png) |
-+------+---+------+----------------------------------------+------+------+
-| 2.3  | 1 |      | P. Launay: Spécification des           | ![]  | ![]  |
-|      | 1 |      | structures de données                  | (ver | (ver |
-|      | / |      |                                        | topa | topa |
-|      | 1 |      |                                        | l_d5 | l_d5 |
-|      | 0 |      |                                        | b45b | b45b |
-|      | / |      |                                        | 6900 | 6900 |
-|      | 9 |      |                                        | c449 | c449 |
-|      | 9 |      |                                        | bd9c | bd9c |
-|      |   |      |                                        | d55a | d55a |
-|      |   |      |                                        | 0f4a | 0f4a |
-|      |   |      |                                        | cdb4 | cdb4 |
-|      |   |      |                                        | a7/m | a7/m |
-|      |   |      |                                        | edia | edia |
-|      |   |      |                                        | /ima | /ima |
-|      |   |      |                                        | ge4. | ge3. |
-|      |   |      |                                        | png) | png) |
-+------+---+------+----------------------------------------+------+------+
-| 2.4  | 1 |      | P. Launay: Spécification des Services  | ![]  | ![]  |
-|      | 2 |      | et modification des règles de nommage  | (ver | (ver |
-|      | / |      | des entités                            | topa | topa |
-|      | 1 |      |                                        | l_d5 | l_d5 |
-|      | 0 |      |                                        | b45b | b45b |
-|      | / |      |                                        | 6900 | 6900 |
-|      | 9 |      |                                        | c449 | c449 |
-|      | 9 |      |                                        | bd9c | bd9c |
-|      |   |      |                                        | d55a | d55a |
-|      |   |      |                                        | 0f4a | 0f4a |
-|      |   |      |                                        | cdb4 | cdb4 |
-|      |   |      |                                        | a7/m | a7/m |
-|      |   |      |                                        | edia | edia |
-|      |   |      |                                        | /ima | /ima |
-|      |   |      |                                        | ge4. | ge3. |
-|      |   |      |                                        | png) | png) |
-+------+---+------+----------------------------------------+------+------+
-| 3.1  | 1 |      | P. Launay: Ajout des tables            | ![]  | ![]  |
-|      | 3 |      | d\'administration des évènements       | (ver | (ver |
-|      | / |      |                                        | topa | topa |
-|      | 1 |      |                                        | l_d5 | l_d5 |
-|      | 0 |      |                                        | b45b | b45b |
-|      | / |      |                                        | 6900 | 6900 |
-|      | 9 |      |                                        | c449 | c449 |
-|      | 9 |      |                                        | bd9c | bd9c |
-|      |   |      |                                        | d55a | d55a |
-|      |   |      |                                        | 0f4a | 0f4a |
-|      |   |      |                                        | cdb4 | cdb4 |
-|      |   |      |                                        | a7/m | a7/m |
-|      |   |      |                                        | edia | edia |
-|      |   |      |                                        | /ima | /ima |
-|      |   |      |                                        | ge4. | ge3. |
-|      |   |      |                                        | png) | png) |
-+------+---+------+----------------------------------------+------+------+
-| 3.2  | 2 |      | P. Launay: Aojut de nouveaux champs    | ![]  | ![]  |
-|      | 6 |      | dans les descriptifs de table          | (ver | (ver |
-|      | / |      |                                        | topa | topa |
-|      | 1 |      |                                        | l_d5 | l_d5 |
-|      | 0 |      |                                        | b45b | b45b |
-|      | / |      |                                        | 6900 | 6900 |
-|      | 9 |      |                                        | c449 | c449 |
-|      | 9 |      |                                        | bd9c | bd9c |
-|      |   |      |                                        | d55a | d55a |
-|      |   |      |                                        | 0f4a | 0f4a |
-|      |   |      |                                        | cdb4 | cdb4 |
-|      |   |      |                                        | a7/m | a7/m |
-|      |   |      |                                        | edia | edia |
-|      |   |      |                                        | /ima | /ima |
-|      |   |      |                                        | ge4. | ge3. |
-|      |   |      |                                        | png) | png) |
-+------+---+------+----------------------------------------+------+------+
-| 4.1  | 2 |      | P. Launay: Ajout des demandes          | ![]  | ![]  |
-|      | 9 |      | d\'examens                             | (ver | (ver |
-|      | / |      |                                        | topa | topa |
-|      | 1 |      |                                        | l_d5 | l_d5 |
-|      | 1 |      |                                        | b45b | b45b |
-|      | / |      |                                        | 6900 | 6900 |
-|      | 9 |      |                                        | c449 | c449 |
-|      | 9 |      |                                        | bd9c | bd9c |
-|      |   |      |                                        | d55a | d55a |
-|      |   |      |                                        | 0f4a | 0f4a |
-|      |   |      |                                        | cdb4 | cdb4 |
-|      |   |      |                                        | a7/m | a7/m |
-|      |   |      |                                        | edia | edia |
-|      |   |      |                                        | /ima | /ima |
-|      |   |      |                                        | ge4. | ge3. |
-|      |   |      |                                        | png) | png) |
-+------+---+------+----------------------------------------+------+------+
-| 4.2  | 2 |      | P. Launay: Ajout des minutes de        | ![]  | ![]  |
-|      | 5 |      | naissance au message ID, MA (Page 15)  | (ver | (ver |
-|      | / |      |                                        | topa | topa |
-|      | 0 |      |                                        | l_d5 | l_d5 |
-|      | 5 |      |                                        | b45b | b45b |
-|      | / |      |                                        | 6900 | 6900 |
-|      | 0 |      |                                        | c449 | c449 |
-|      | 0 |      |                                        | bd9c | bd9c |
-|      |   |      |                                        | d55a | d55a |
-|      |   |      |                                        | 0f4a | 0f4a |
-|      |   |      |                                        | cdb4 | cdb4 |
-|      |   |      |                                        | a7/m | a7/m |
-|      |   |      |                                        | edia | edia |
-|      |   |      |                                        | /ima | /ima |
-|      |   |      |                                        | ge4. | ge3. |
-|      |   |      |                                        | png) | png) |
-+------+---+------+----------------------------------------+------+------+
-| 5.0  | 2 |      | R. Gill: Mise à jour pour Hexagone v7  | ![]  | ![]  |
-|      | 5 |      | b.18                                   | (ver | (ver |
-|      | / |      |                                        | topa | topa |
-|      | 1 |      |                                        | l_d5 | l_d5 |
-|      | 0 |      |                                        | b45b | b45b |
-|      | / |      |                                        | 6900 | 6900 |
-|      | 0 |      |                                        | c449 | c449 |
-|      | 0 |      |                                        | bd9c | bd9c |
-|      |   |      |                                        | d55a | d55a |
-|      |   |      |                                        | 0f4a | 0f4a |
-|      |   |      |                                        | cdb4 | cdb4 |
-|      |   |      |                                        | a7/m | a7/m |
-|      |   |      |                                        | edia | edia |
-|      |   |      |                                        | /ima | /ima |
-|      |   |      |                                        | ge4. | ge3. |
-|      |   |      |                                        | png) | png) |
-+------+---+------+----------------------------------------+------+------+
-| 5.2  | 2 |      | P. Launay : Ajout des messages         | ![]  | ![]  |
-|      | 2 |      | d\'actes en *NGAP* et en *CDAM*        | (ver | (ver |
-|      | / |      |                                        | topa | topa |
-|      | 0 |      |                                        | l_d5 | l_d5 |
-|      | 5 |      |                                        | b45b | b45b |
-|      | / |      |                                        | 6900 | 6900 |
-|      | 0 |      |                                        | c449 | c449 |
-|      | 1 |      |                                        | bd9c | bd9c |
-|      |   |      |                                        | d55a | d55a |
-|      |   |      |                                        | 0f4a | 0f4a |
-|      |   |      |                                        | cdb4 | cdb4 |
-|      |   |      |                                        | a7/m | a7/m |
-|      |   |      |                                        | edia | edia |
-|      |   |      |                                        | /ima | /ima |
-|      |   |      |                                        | ge4. | ge3. |
-|      |   |      |                                        | png) | png) |
-+------+---+------+----------------------------------------+------+------+
-| 6.1  | 0 |      | P. Launay : Modification de messages   | ![]  | ![]  |
-|      | 4 |      | et ajout de messages (ID M1 page 15,   | (ver | (ver |
-|      | / |      | IY M1, page 17, MV M2 page 19, MV M3   | topa | topa |
-|      | 0 |      | page 20, MV M6 page 22, MV M7 page 23, | l_d5 | l_d5 |
-|      | 1 |      | MV M8 page 24 et MV M9 page 25)        | b45b | b45b |
-|      | / |      |                                        | 6900 | 6900 |
-|      | 0 |      |                                        | c449 | c449 |
-|      | 2 |      |                                        | bd9c | bd9c |
-|      |   |      |                                        | d55a | d55a |
-|      |   |      |                                        | 0f4a | 0f4a |
-|      |   |      |                                        | cdb4 | cdb4 |
-|      |   |      |                                        | a7/m | a7/m |
-|      |   |      |                                        | edia | edia |
-|      |   |      |                                        | /ima | /ima |
-|      |   |      |                                        | ge4. | ge3. |
-|      |   |      |                                        | png) | png) |
-+------+---+------+----------------------------------------+------+------+
-| 6.2  | 2 |      | P. Launay : Modification du message IY | ![]  | ![]  |
-|      | 3 |      | page 17.                               | (ver | (ver |
-|      | / |      |                                        | topa | topa |
-|      | 0 |      |                                        | l_d5 | l_d5 |
-|      | 1 |      |                                        | b45b | b45b |
-|      | / |      |                                        | 6900 | 6900 |
-|      | 0 |      |                                        | c449 | c449 |
-|      | 2 |      |                                        | bd9c | bd9c |
-|      |   |      |                                        | d55a | d55a |
-|      |   |      |                                        | 0f4a | 0f4a |
-|      |   |      |                                        | cdb4 | cdb4 |
-|      |   |      |                                        | a7/m | a7/m |
-|      |   |      |                                        | edia | edia |
-|      |   |      |                                        | /ima | /ima |
-|      |   |      |                                        | ge4. | ge3. |
-|      |   |      |                                        | png) | png) |
-+------+---+------+----------------------------------------+------+------+
-| 6.3  | 2 |      | R. Gill: Ajout de la description de    | ![]  | ![]  |
-|      | 4 |      | table HNDGHL7, et de la communication  | (ver | (ver |
-|      | / |      | par IHE/HL7                            | topa | topa |
-|      | 0 |      |                                        | l_d5 | l_d5 |
-|      | 1 |      |                                        | b45b | b45b |
-|      | / |      |                                        | 6900 | 6900 |
-|      | 0 |      |                                        | c449 | c449 |
-|      | 2 |      |                                        | bd9c | bd9c |
-|      |   |      |                                        | d55a | d55a |
-|      |   |      |                                        | 0f4a | 0f4a |
-|      |   |      |                                        | cdb4 | cdb4 |
-|      |   |      |                                        | a7/m | a7/m |
-|      |   |      |                                        | edia | edia |
-|      |   |      |                                        | /ima | /ima |
-|      |   |      |                                        | ge4. | ge3. |
-|      |   |      |                                        | png) | png) |
-+------+---+------+----------------------------------------+------+------+
-| 6.4  | 2 |      | R. Gill: Ajout du champ Uf précédente  | ![]  | ![]  |
-|      | 5 |      | dans le message M6                     | (ver | (ver |
-|      | / |      |                                        | topa | topa |
-|      | 0 |      |                                        | l_d5 | l_d5 |
-|      | 1 |      |                                        | b45b | b45b |
-|      | / |      |                                        | 6900 | 6900 |
-|      | 0 |      |                                        | c449 | c449 |
-|      | 2 |      |                                        | bd9c | bd9c |
-|      |   |      |                                        | d55a | d55a |
-|      |   |      |                                        | 0f4a | 0f4a |
-|      |   |      |                                        | cdb4 | cdb4 |
-|      |   |      |                                        | a7/m | a7/m |
-|      |   |      |                                        | edia | edia |
-|      |   |      |                                        | /ima | /ima |
-|      |   |      |                                        | ge4. | ge3. |
-|      |   |      |                                        | png) | png) |
-+------+---+------+----------------------------------------+------+------+
-| 7.0  | 2 |      | P.Launay : Ajout des messages UF       | ![]  | ![]  |
-|      | 7 |      |                                        | (ver | (ver |
-|      | / |      |                                        | topa | topa |
-|      | 0 |      |                                        | l_d5 | l_d5 |
-|      | 2 |      |                                        | b45b | b45b |
-|      | / |      |                                        | 6900 | 6900 |
-|      | 0 |      |                                        | c449 | c449 |
-|      | 2 |      |                                        | bd9c | bd9c |
-|      |   |      |                                        | d55a | d55a |
-|      |   |      |                                        | 0f4a | 0f4a |
-|      |   |      |                                        | cdb4 | cdb4 |
-|      |   |      |                                        | a7/m | a7/m |
-|      |   |      |                                        | edia | edia |
-|      |   |      |                                        | /ima | /ima |
-|      |   |      |                                        | ge4. | ge3. |
-|      |   |      |                                        | png) | png) |
-+------+---+------+----------------------------------------+------+------+
-| 7.1  | 2 |      | P.Launay : Ajouts des messages         | ![]  | ![]  |
-|      | 9 |      | Produits                               | (ver | (ver |
-|      | / |      |                                        | topa | topa |
-|      | 0 |      |                                        | l_d5 | l_d5 |
-|      | 4 |      |                                        | b45b | b45b |
-|      | / |      |                                        | 6900 | 6900 |
-|      | 0 |      |                                        | c449 | c449 |
-|      | 2 |      |                                        | bd9c | bd9c |
-|      |   |      |                                        | d55a | d55a |
-|      |   |      |                                        | 0f4a | 0f4a |
-|      |   |      |                                        | cdb4 | cdb4 |
-|      |   |      |                                        | a7/m | a7/m |
-|      |   |      |                                        | edia | edia |
-|      |   |      |                                        | /ima | /ima |
-|      |   |      |                                        | ge4. | ge3. |
-|      |   |      |                                        | png) | png) |
-+------+---+------+----------------------------------------+------+------+
-| 7.2  | 2 |      | C. Madrid : Ajout dans le message M8   | ![]  | ![]  |
-|      | 2 |      | du motif de l'absence                  | (ver | (ver |
-|      | / |      |                                        | topa | topa |
-|      | 0 |      |                                        | l_d5 | l_d5 |
-|      | 7 |      |                                        | b45b | b45b |
-|      | / |      |                                        | 6900 | 6900 |
-|      | 0 |      |                                        | c449 | c449 |
-|      | 2 |      |                                        | bd9c | bd9c |
-|      |   |      |                                        | d55a | d55a |
-|      |   |      |                                        | 0f4a | 0f4a |
-|      |   |      |                                        | cdb4 | cdb4 |
-|      |   |      |                                        | a7/m | a7/m |
-|      |   |      |                                        | edia | edia |
-|      |   |      |                                        | /ima | /ima |
-|      |   |      |                                        | ge4. | ge3. |
-|      |   |      |                                        | png) | png) |
-+------+---+------+----------------------------------------+------+------+
-| 7.3  | 2 |      | I.Ravet : Modification des messages    | ![]  | ![]  |
-|      | 5 |      | Utilisateurs                           | (ver | (ver |
-|      | / |      |                                        | topa | topa |
-|      | 1 |      |                                        | l_d5 | l_d5 |
-|      | 0 |      |                                        | b45b | b45b |
-|      | / |      |                                        | 6900 | 6900 |
-|      | 0 |      |                                        | c449 | c449 |
-|      | 2 |      |                                        | bd9c | bd9c |
-|      |   |      |                                        | d55a | d55a |
-|      |   |      |                                        | 0f4a | 0f4a |
-|      |   |      |                                        | cdb4 | cdb4 |
-|      |   |      |                                        | a7/m | a7/m |
-|      |   |      |                                        | edia | edia |
-|      |   |      |                                        | /ima | /ima |
-|      |   |      |                                        | ge4. | ge3. |
-|      |   |      |                                        | png) | png) |
-+------+---+------+----------------------------------------+------+------+
-| 7.4  | 1 |      | P. Launay : Modification des messages  | ![]  | ![]  |
-|      | 3 |      | Actes                                  | (ver | (ver |
-|      | / |      |                                        | topa | topa |
-|      | 1 |      |                                        | l_d5 | l_d5 |
-|      | 1 |      |                                        | b45b | b45b |
-|      | / |      |                                        | 6900 | 6900 |
-|      | 0 |      |                                        | c449 | c449 |
-|      | 2 |      |                                        | bd9c | bd9c |
-|      |   |      |                                        | d55a | d55a |
-|      |   |      |                                        | 0f4a | 0f4a |
-|      |   |      |                                        | cdb4 | cdb4 |
-|      |   |      |                                        | a7/m | a7/m |
-|      |   |      |                                        | edia | edia |
-|      |   |      |                                        | /ima | /ima |
-|      |   |      |                                        | ge4. | ge3. |
-|      |   |      |                                        | png) | png) |
-+------+---+------+----------------------------------------+------+------+
-| 7.5  | 1 |      | I.Ravet : Mise à jour des messages     | ![]  | ![]  |
-|      | 5 |      | Utilisateurs v7.c10                    | (ver | (ver |
-|      | / |      |                                        | topa | topa |
-|      | 1 |      |                                        | l_d5 | l_d5 |
-|      | 1 |      |                                        | b45b | b45b |
-|      | / |      |                                        | 6900 | 6900 |
-|      | 0 |      |                                        | c449 | c449 |
-|      | 2 |      |                                        | bd9c | bd9c |
-|      |   |      |                                        | d55a | d55a |
-|      |   |      |                                        | 0f4a | 0f4a |
-|      |   |      |                                        | cdb4 | cdb4 |
-|      |   |      |                                        | a7/m | a7/m |
-|      |   |      |                                        | edia | edia |
-|      |   |      |                                        | /ima | /ima |
-|      |   |      |                                        | ge4. | ge3. |
-|      |   |      |                                        | png) | png) |
-+------+---+------+----------------------------------------+------+------+
-| 7.6  | 2 |      | C. Alphand : Ajout des messages ST/EJ  | ![]  | ![]  |
-|      | 8 |      | et ST/EG                               | (ver | (ver |
-|      | / |      |                                        | topa | topa |
-|      | 1 |      |                                        | l_d5 | l_d5 |
-|      | 1 |      |                                        | b45b | b45b |
-|      | / |      |                                        | 6900 | 6900 |
-|      | 2 |      |                                        | c449 | c449 |
-|      | 0 |      |                                        | bd9c | bd9c |
-|      | 0 |      |                                        | d55a | d55a |
-|      | 2 |      |                                        | 0f4a | 0f4a |
-|      |   |      |                                        | cdb4 | cdb4 |
-|      |   |      |                                        | a7/m | a7/m |
-|      |   |      |                                        | edia | edia |
-|      |   |      |                                        | /ima | /ima |
-|      |   |      |                                        | ge4. | ge3. |
-|      |   |      |                                        | png) | png) |
-+------+---+------+----------------------------------------+------+------+
-| 7.7  | 0 |      | P. Launay : Mise en page par domaine   | ![]  | ![]  |
-|      | 2 |      |                                        | (ver | (ver |
-|      | / |      |                                        | topa | topa |
-|      | 0 |      |                                        | l_d5 | l_d5 |
-|      | 1 |      |                                        | b45b | b45b |
-|      | / |      |                                        | 6900 | 6900 |
-|      | 0 |      |                                        | c449 | c449 |
-|      | 3 |      |                                        | bd9c | bd9c |
-|      |   |      |                                        | d55a | d55a |
-|      |   |      |                                        | 0f4a | 0f4a |
-|      |   |      |                                        | cdb4 | cdb4 |
-|      |   |      |                                        | a7/m | a7/m |
-|      |   |      |                                        | edia | edia |
-|      |   |      |                                        | /ima | /ima |
-|      |   |      |                                        | ge4. | ge3. |
-|      |   |      |                                        | png) | png) |
-+------+---+------+----------------------------------------+------+------+
-| 7.8  | 0 |      | V. Amorin : Ajout n°Finess dans les    | ![]  | ![]  |
-|      | 4 |      | messages UF (p20)                      | (ver | (ver |
-|      | / |      |                                        | topa | topa |
-|      | 0 |      |                                        | l_d5 | l_d5 |
-|      | 3 |      |                                        | b45b | b45b |
-|      | / |      |                                        | 6900 | 6900 |
-|      | 0 |      |                                        | c449 | c449 |
-|      | 3 |      |                                        | bd9c | bd9c |
-|      |   |      |                                        | d55a | d55a |
-|      |   |      |                                        | 0f4a | 0f4a |
-|      |   |      |                                        | cdb4 | cdb4 |
-|      |   |      |                                        | a7/m | a7/m |
-|      |   |      |                                        | edia | edia |
-|      |   |      |                                        | /ima | /ima |
-|      |   |      |                                        | ge4. | ge3. |
-|      |   |      |                                        | png) | png) |
-+------+---+------+----------------------------------------+------+------+
-| 7.9  | 1 |      | JM Gio : Ajout identifiant cps et      | ![]  | ![]  |
-|      | 5 |      | liste des uf et des finess dans les    | (ver | (ver |
-|      | / |      | messages création et modification      | topa | topa |
-|      | 0 |      | Praticiens et modification message     | l_d5 | l_d5 |
-|      | 4 |      | suppression                            | b45b | b45b |
-|      | / |      |                                        | 6900 | 6900 |
-|      | 0 |      |                                        | c449 | c449 |
-|      | 3 |      |                                        | bd9c | bd9c |
-|      |   |      |                                        | d55a | d55a |
-|      |   |      |                                        | 0f4a | 0f4a |
-|      |   |      |                                        | cdb4 | cdb4 |
-|      |   |      |                                        | a7/m | a7/m |
-|      |   |      |                                        | edia | edia |
-|      |   |      |                                        | /ima | /ima |
-|      |   |      |                                        | ge4. | ge3. |
-|      |   |      |                                        | png) | png) |
-+------+---+------+----------------------------------------+------+------+
-| 7.10 | 1 |      | C.Alphand : Nouveau message ID M5      | ![]  | ![]  |
-|      | 0 |      |                                        | (ver | (ver |
-|      | / |      | C.Alphand : Message ID M1 rajout       | topa | topa |
-|      | 0 |      | sipprentot                             | l_d5 | l_d5 |
-|      | 2 |      |                                        | b45b | b45b |
-|      | / |      |                                        | 6900 | 6900 |
-|      | 2 |      |                                        | c449 | c449 |
-|      | 0 |      |                                        | bd9c | bd9c |
-|      | 0 |      |                                        | d55a | d55a |
-|      | 4 |      |                                        | 0f4a | 0f4a |
-|      |   |      |                                        | cdb4 | cdb4 |
-|      |   |      |                                        | a7/m | a7/m |
-|      |   |      |                                        | edia | edia |
-|      |   |      |                                        | /ima | /ima |
-|      |   |      |                                        | ge4. | ge3. |
-|      |   |      |                                        | png) | png) |
-+------+---+------+----------------------------------------+------+------+
-| 8.01 | 0 |      | Mise a jour charte graphique, et       | ![]  | ![]  |
-|      | 5 |      | Elite.S                                | (ver | (ver |
-|      | / |      |                                        | topa | topa |
-|      | 0 |      |                                        | l_d5 | l_d5 |
-|      | 3 |      |                                        | b45b | b45b |
-|      | / |      |                                        | 6900 | 6900 |
-|      | 0 |      |                                        | c449 | c449 |
-|      | 4 |      |                                        | bd9c | bd9c |
-|      |   |      |                                        | d55a | d55a |
-|      |   |      |                                        | 0f4a | 0f4a |
-|      |   |      |                                        | cdb4 | cdb4 |
-|      |   |      |                                        | a7/m | a7/m |
-|      |   |      |                                        | edia | edia |
-|      |   |      |                                        | /ima | /ima |
-|      |   |      |                                        | ge4. | ge3. |
-|      |   |      |                                        | png) | png) |
-+------+---+------+----------------------------------------+------+------+
-| 8.02 | 2 |      | JP. Pereira : Messages Elite.S         | ![]  | ![]  |
-|      | 3 |      | disponibles à partir de la version     | (ver | (ver |
-|      | / |      | D.03                                   | topa | topa |
-|      | 0 |      |                                        | l_d5 | l_d5 |
-|      | 9 |      | Ajout message PR M7, SO LI             | b45b | b45b |
-|      | / |      | -Modifications messages PR M0, PR M1,  | 6900 | 6900 |
-|      | 0 |      | PR M3,PR M4, FO M3, CO CE, CO CL.      | c449 | c449 |
-|      | 4 |      |                                        | bd9c | bd9c |
-|      |   |      |                                        | d55a | d55a |
-|      |   |      |                                        | 0f4a | 0f4a |
-|      |   |      |                                        | cdb4 | cdb4 |
-|      |   |      |                                        | a7/m | a7/m |
-|      |   |      |                                        | edia | edia |
-|      |   |      |                                        | /ima | /ima |
-|      |   |      |                                        | ge4. | ge3. |
-|      |   |      |                                        | png) | png) |
-+------+---+------+----------------------------------------+------+------+
-| 8.03 | 1 |      | C.Alphand : Message ID\|M1 ajout des   | ![]  | ![]  |
-|      | 4 |      | zones télécom (D03), des autres        | (ver | (ver |
-|      | / |      | adresses (D03), modification identité  | topa | topa |
-|      | 0 |      | protégée (D03.1)                       | l_d5 | l_d5 |
-|      | 4 |      |                                        | b45b | b45b |
-|      | / |      | Message CV ajout du type, numéro de    | 6900 | 6900 |
-|      | 0 |      | dossier, zone prévisionnel (D03)       | c449 | c449 |
-|      | 5 |      |                                        | bd9c | bd9c |
-|      |   |      | A la fin du message ID\|M1 (position   | d55a | d55a |
-|      | 2 |      | 45) ajout de l'ipp du patient à garder | 0f4a | 0f4a |
-|      | 6 |      | si c'est une fusion de patient sinon   | cdb4 | cdb4 |
-|      | / |      | vide (disponible en D04).              | a7/m | a7/m |
-|      | 0 |      |                                        | edia | edia |
-|      | 5 |      | A la fin du message MV\|M4 (position   | /ima | /ima |
-|      | / |      | 10) ajout de F si c'est une fusion de  | ge4. | ge3. |
-|      | 0 |      | patient sinon vide (disponible en      | png) | png) |
-|      | 5 |      | D04).                                  |      |      |
-+------+---+------+----------------------------------------+------+------+
-| 8.04 | 1 |      | C.Alphand : Message ID\|M1 ajout des   | ![]  | ![]  |
-|      | 4 |      | zones (En D04) : Cp du lieu de         | (ver | (ver |
-|      | / |      | naissance, pays de naissance, VIP,     | topa | topa |
-|      | 0 |      | Identité à valider                     | l_d5 | l_d5 |
-|      | 9 |      |                                        | b45b | b45b |
-|      | / |      |                                        | 6900 | 6900 |
-|      | 0 |      |                                        | c449 | c449 |
-|      | 5 |      |                                        | bd9c | bd9c |
-|      |   |      |                                        | d55a | d55a |
-|      |   |      |                                        | 0f4a | 0f4a |
-|      |   |      |                                        | cdb4 | cdb4 |
-|      |   |      |                                        | a7/m | a7/m |
-|      |   |      |                                        | edia | edia |
-|      |   |      |                                        | /ima | /ima |
-|      |   |      |                                        | ge4. | ge3. |
-|      |   |      |                                        | png) | png) |
-+------+---+------+----------------------------------------+------+------+
-| 8.05 | 1 |      | Philippe LAUNAY : Ajout des messages   | ![]  | ![]  |
-|      | 2 |      | propres aux Box Urgences.              | (ver | (ver |
-|      | / |      |                                        | topa | topa |
-|      | 1 |      |                                        | l_d5 | l_d5 |
-|      | 0 |      |                                        | b45b | b45b |
-|      | / |      |                                        | 6900 | 6900 |
-|      | 0 |      |                                        | c449 | c449 |
-|      | 5 |      |                                        | bd9c | bd9c |
-|      |   |      |                                        | d55a | d55a |
-|      |   |      |                                        | 0f4a | 0f4a |
-|      |   |      |                                        | cdb4 | cdb4 |
-|      |   |      |                                        | a7/m | a7/m |
-|      |   |      |                                        | edia | edia |
-|      |   |      |                                        | /ima | /ima |
-|      |   |      |                                        | ge4. | ge3. |
-|      |   |      |                                        | png) | png) |
-+------+---+------+----------------------------------------+------+------+
-| 8.06 | 0 |      | C.Alphand : Ajout à la fin du message  | ![]  | ![]  |
-|      | 2 |      | NO\|PR (praticiens) du nom et prénom   | (ver | (ver |
-|      | / |      | (disponible en D03.7)                  | topa | topa |
-|      | 0 |      |                                        | l_d5 | l_d5 |
-|      | 1 |      | C.Alphand N.Gaillard : (disponible en  | b45b | b45b |
-|      | / |      | D03.8)                                 | 6900 | 6900 |
-|      | 0 |      |                                        | c449 | c449 |
-|      | 6 |      | -   nouveaux messages Structure        | bd9c | bd9c |
-|      |   |      |     (Bâtiment, Etage, Pièce, Pièce/UF, | d55a | d55a |
-|      |   |      |     Lit, Service)                      | 0f4a | 0f4a |
-|      |   |      |                                        | cdb4 | cdb4 |
-|      |   |      | -   ajout etab juridique à la fin du   | a7/m | a7/m |
-|      |   |      |     message ST\|EG                     | edia | edia |
-|      |   |      |                                        | /ima | /ima |
-|      |   |      | > C.Alphand (disponibles en D03.8)     | ge4. | ge3. |
-|      |   |      | > nouveau message NO\|ET               | png) | png) |
-+------+---+------+----------------------------------------+------+------+
-| 8.07 | 1 |      | > X.DELOIRE : Ajout des messages de    | ![]  | ![]  |
-|      | 1 |      | > fin de séance et de fin de venue     | (ver | (ver |
-|      | / |      |                                        | topa | topa |
-|      | 0 |      |                                        | l_d5 | l_d5 |
-|      | 1 |      |                                        | b45b | b45b |
-|      | / |      |                                        | 6900 | 6900 |
-|      | 0 |      |                                        | c449 | c449 |
-|      | 6 |      |                                        | bd9c | bd9c |
-|      |   |      |                                        | d55a | d55a |
-|      |   |      |                                        | 0f4a | 0f4a |
-|      |   |      |                                        | cdb4 | cdb4 |
-|      |   |      |                                        | a7/m | a7/m |
-|      |   |      |                                        | edia | edia |
-|      |   |      |                                        | /ima | /ima |
-|      |   |      |                                        | ge4. | ge3. |
-|      |   |      |                                        | png) | png) |
-+------+---+------+----------------------------------------+------+------+
-| 9.00 | 0 |      | > C.Alphand (disponible en D03.9) :    |      |      |
-|      | 2 |      | >                                      |      |      |
-|      | / |      | > \- Ajout message ST\|B1 structure    |      |      |
-|      | 0 |      | > Box                                  |      |      |
-|      | 3 |      | >                                      |      |      |
-|      | / |      | > \- Ajout type + étage dans le        |      |      |
-|      | 0 |      | > message ST\|LI                       |      |      |
-|      | 6 |      | >                                      |      |      |
-|      |   |      | > \- Ajout type dans le message ST\|UP |      |      |
-|      |   |      | >                                      |      |      |
-|      |   |      | > \- Modif message ID\`M1 M lors d'une |      |      |
-|      |   |      | > fusion                               |      |      |
-|      |   |      | >                                      |      |      |
-|      |   |      | > \- Modif message ID M1 ajout de      |      |      |
-|      |   |      | > l'AQS + modif pour les pièces        |      |      |
-|      |   |      | > justifiants l'identité               |      |      |
-|      |   |      | >                                      |      |      |
-|      |   |      | > -Ajout message UF\|U1 : type de      |      |      |
-|      |   |      | > séjour et type de pmsi               |      |      |
-|      |   |      | >                                      |      |      |
-|      |   |      | > \- Message ID\|M1 : les autres       |      |      |
-|      |   |      | > adresses d'un patient sont séparées  |      |      |
-|      |   |      | > par \^ (suppression du retour        |      |      |
-|      |   |      | > chariot pour séparées 2 adresses)    |      |      |
-|      |   |      | >                                      |      |      |
-|      |   |      | > \- Nouveaux messages : Zones         |      |      |
-|      |   |      | > (ST\|ZO), secteurs (ST\|SC)          |      |      |
-|      |   |      | >                                      |      |      |
-|      |   |      | > \- Modification du message CV\|M1    |      |      |
-+------+---+------+----------------------------------------+------+------+
-| 1    | 1 |      | > XDeloire (disponible en D03.10) :    |      |      |
-| 0.00 | 3 |      | >                                      |      |      |
-|      | / |      | > \- Ajout message MV\|L1 Libération   |      |      |
-|      | 0 |      | > lits pour fin de séances et venues   |      |      |
-|      | 6 |      | >                                      |      |      |
-|      | / |      | > \- Ajout message MV\|FX de fin de    |      |      |
-|      | 0 |      | > consultation                         |      |      |
-|      | 6 |      | >                                      |      |      |
-|      |   |      | > C.Alphand (disponible en D03.10)     |      |      |
-|      |   |      | >                                      |      |      |
-|      |   |      | > -Ajout dans le message ID M1 :       |      |      |
-|      |   |      | > identité usurpée, ressortissant,     |      |      |
-|      |   |      | > niveau d'étude, pays des adresses au |      |      |
-|      |   |      | > format code iso, pays de naissances  |      |      |
-|      |   |      | > (format code iso)                    |      |      |
-|      |   |      | >                                      |      |      |
-|      |   |      | > \- Message ST\|B1 : ajout Zone et    |      |      |
-|      |   |      | > secteur                              |      |      |
-|      |   |      | >                                      |      |      |
-|      |   |      | > \- Message NO\|NA (nationalités)     |      |      |
-|      |   |      | > suppression du code langue et        |      |      |
-|      |   |      | > longueur cp dans le message de       |      |      |
-|      |   |      | > création et modification (ces        |      |      |
-|      |   |      | > données sont désormais à prendre     |      |      |
-|      |   |      | > dans la table des pays)              |      |      |
-|      |   |      | >                                      |      |      |
-|      |   |      | > \- Nouveau message NO\|PA : pays     |      |      |
-+------+---+------+----------------------------------------+------+------+
-|      | 1 |      | > M. Dupont : Modification des         |      |      |
-|      | 2 |      | > messages UF U1 C et UF U1 M          |      |      |
-|      | / |      | > concernant hxunite : secana sur 10   |      |      |
-|      | 0 |      | > caractères au lieu de 8.             |      |      |
-|      | 9 |      |                                        |      |      |
-|      | / |      |                                        |      |      |
-|      | 0 |      |                                        |      |      |
-|      | 6 |      |                                        |      |      |
-+------+---+------+----------------------------------------+------+------+
-| 1    | 0 |      | > C.Alphand (disponible en D03.11)     |      |      |
-| 1.00 | 7 |      | >                                      |      |      |
-|      | / |      | > -Ajout dans le message ID M1  :      |      |      |
-|      | 1 |      | > heure de décès, minute de décès,     |      |      |
-|      | 2 |      | > personnel hospitalier                |      |      |
-|      | / |      | >                                      |      |      |
-|      | 0 |      | > -Ajout dans le message ST\|EJ : IBAN |      |      |
-|      | 6 |      | > et BIC                               |      |      |
-|      |   |      | >                                      |      |      |
-|      |   |      | > \- Nouveau message ID\|MT : Médecin  |      |      |
-|      |   |      | > traitant                             |      |      |
-|      |   |      | >                                      |      |      |
-|      |   |      | > \- Ajout message No\|OR date de fin  |      |      |
-|      |   |      | > de validité + nouveau code organisme |      |      |
-+------+---+------+----------------------------------------+------+------+
-| 1    | 0 |      | > Ajout de la date de sortie des       |      |      |
-| 1.00 | 7 |      | > urgences pour M2 (D03.10.5)          |      |      |
-|      | / |      |                                        |      |      |
-|      | 0 |      |                                        |      |      |
-|      | 2 |      |                                        |      |      |
-|      | / |      |                                        |      |      |
-|      | 0 |      |                                        |      |      |
-|      | 7 |      |                                        |      |      |
-+------+---+------+----------------------------------------+------+------+
-| 1    | 0 |      | > XD : Ajout du chrono du mode de      |      |      |
-| 1.00 | 9 |      | > placement dans les messages IY.      |      |      |
-|      | / |      | > Ajout des anciens et nouveaux motif  |      |      |
-|      | 0 |      | > de venue et UF dans les messages M3. |      |      |
-|      | 3 |      |                                        |      |      |
-|      | / |      |                                        |      |      |
-|      | 0 |      |                                        |      |      |
-|      | 7 |      |                                        |      |      |
-+------+---+------+----------------------------------------+------+------+
-| 1    | 3 |      | > CA (disponible en D03.12) :          |      |      |
-| 2.00 | 1 |      | >                                      |      |      |
-|      | / |      | > -ajout dans NO\|ET (nomenclature     |      |      |
-|      | 0 |      | > statut du parcours) : Origine de     |      |      |
-|      | 1 |      | > prescription et saisie médecin       |      |      |
-|      | / |      | >                                      |      |      |
-|      | 0 |      | > -Message des praticiens (ajout       |      |      |
-|      | 8 |      | > civilité, Titre, RPPS)               |      |      |
-+------+---+------+----------------------------------------+------+------+
-| 1    | 1 |      | > RG : Ajout Date de saisie d'origine  |      |      |
-| 2.00 | 6 |      | > sur le M3 pour traiter un problème   |      |      |
-|      | / |      | > de re-génération.                    |      |      |
-|      | 0 |      |                                        |      |      |
-|      | 2 |      |                                        |      |      |
-|      | / |      |                                        |      |      |
-|      | 0 |      |                                        |      |      |
-|      | 8 |      |                                        |      |      |
-+------+---+------+----------------------------------------+------+------+
-| 1    | 0 |      | > CA : Ajout RPSS dans le message      |      |      |
-| 3.00 | 9 |      | > ID\|MT                               |      |      |
-|      | / |      |                                        |      |      |
-|      | 0 |      |                                        |      |      |
-|      | 3 |      |                                        |      |      |
-|      | / |      |                                        |      |      |
-|      | 0 |      |                                        |      |      |
-|      | 9 |      |                                        |      |      |
-+------+---+------+----------------------------------------+------+------+
-| 1    | 1 |      | > CA : Ajout INSC et CLEINSC dans le   |      |      |
-| 4.00 | 7 |      | > message ID\|M1                       |      |      |
-|      | / |      |                                        |      |      |
-|      | 0 |      |                                        |      |      |
-|      | 5 |      |                                        |      |      |
-|      | / |      |                                        |      |      |
-|      | 1 |      |                                        |      |      |
-|      | 1 |      |                                        |      |      |
-+------+---+------+----------------------------------------+------+------+
-|      | 0 |      | > CA : Nouveau message ID\|CE (DMP)    |      |      |
-|      | 7 |      |                                        |      |      |
-|      | / |      |                                        |      |      |
-|      | 1 |      |                                        |      |      |
-|      | 1 |      |                                        |      |      |
-|      | / |      |                                        |      |      |
-|      | 1 |      |                                        |      |      |
-|      | 1 |      |                                        |      |      |
-+------+---+------+----------------------------------------+------+------+
-|      | 3 |      | > CA : Ajout date de fin de validité   |      |      |
-|      | 1 |      | > du praticien message NO\|PR          |      |      |
-|      | / |      |                                        |      |      |
-|      | 0 |      |                                        |      |      |
-|      | 1 |      |                                        |      |      |
-|      | / |      |                                        |      |      |
-|      | 1 |      |                                        |      |      |
-|      | 3 |      |                                        |      |      |
-+------+---+------+----------------------------------------+------+------+
-|      | 0 |      | > CA : Ajout code insee message NO\|PA |      |      |
-|      | 2 |      |                                        |      |      |
-|      | / |      |                                        |      |      |
-|      | 0 |      |                                        |      |      |
-|      | 5 |      |                                        |      |      |
-|      | / |      |                                        |      |      |
-|      | 1 |      |                                        |      |      |
-|      | 3 |      |                                        |      |      |
-+------+---+------+----------------------------------------+------+------+
-|      | 0 |      | > RG : Ajout contexte de modification  |      |      |
-|      | 5 |      | > sur le MV\|M2                        |      |      |
-|      | / |      |                                        |      |      |
-|      | 0 |      |                                        |      |      |
-|      | 2 |      |                                        |      |      |
-|      | / |      |                                        |      |      |
-|      | 1 |      |                                        |      |      |
-|      | 4 |      |                                        |      |      |
-+------+---+------+----------------------------------------+------+------+
-|      | 3 |      | > CAL : Ajout IPP fédérateur           |      |      |
-|      | 1 |      | > (PATNUMREG) -- Mess ID               |      |      |
-|      | / |      |                                        |      |      |
-|      | 1 |      |                                        |      |      |
-|      | 1 |      |                                        |      |      |
-|      | / |      |                                        |      |      |
-|      | 1 |      |                                        |      |      |
-|      | 6 |      |                                        |      |      |
-+------+---+------+----------------------------------------+------+------+
-|      | 0 |      | > CAL : Ajout secteur et contrat pour  |      |      |
-|      | 4 |      | > le praticien -- Mess NO\|PR          |      |      |
-|      | / |      |                                        |      |      |
-|      | 0 |      |                                        |      |      |
-|      | 1 |      |                                        |      |      |
-|      | / |      |                                        |      |      |
-|      | 1 |      |                                        |      |      |
-|      | 8 |      |                                        |      |      |
-+------+---+------+----------------------------------------+------+------+
-|      | 0 |      | > CAL : Ajout NUMPASS et passage sur   |      |      |
-|      | 4 |      | > message MV                           |      |      |
-|      | / |      |                                        |      |      |
-|      | 0 |      |                                        |      |      |
-|      | 5 |      |                                        |      |      |
-|      | / |      |                                        |      |      |
-|      | 1 |      |                                        |      |      |
-|      | 8 |      |                                        |      |      |
-+------+---+------+----------------------------------------+------+------+
-|      | 0 |      | > CAL : Ajout DOSNUMA sur message MV   |      |      |
-|      | 4 |      |                                        |      |      |
-|      | / |      |                                        |      |      |
-|      | 0 |      |                                        |      |      |
-|      | 9 |      |                                        |      |      |
-|      | / |      |                                        |      |      |
-|      | 1 |      |                                        |      |      |
-|      | 8 |      |                                        |      |      |
-+------+---+------+----------------------------------------+------+------+
-|      | 1 |      | > CAL : Ajout NIR assuré, Date de      |      |      |
-|      | 2 |      | > naissance bénéficiaire, rand de      |      |      |
-|      | / |      | > naissance bénéficiaire, et quantité  |      |      |
-|      | 0 |      | > du bénéficiaire sur message ID\|CE   |      |      |
-|      | 4 |      |                                        |      |      |
-|      | / |      |                                        |      |      |
-|      | 1 |      |                                        |      |      |
-|      | 9 |      |                                        |      |      |
-+------+---+------+----------------------------------------+------+------+
-|      | 0 |      | > CAL : Ajout NIR bénéficiaire sur     |      |      |
-|      | 9 |      | > message ID\|CE                       |      |      |
-|      | / |      |                                        |      |      |
-|      | 0 |      |                                        |      |      |
-|      | 4 |      |                                        |      |      |
-|      | / |      |                                        |      |      |
-|      | 2 |      |                                        |      |      |
-|      | 0 |      |                                        |      |      |
-+------+---+------+----------------------------------------+------+------+
-| 1    | 1 |      | > PGR : Messages ressources humaines   |      |      |
-| 5.00 | 4 |      |                                        |      |      |
-|      | / |      |                                        |      |      |
-|      | 0 |      |                                        |      |      |
-|      | 9 |      |                                        |      |      |
-|      | / |      |                                        |      |      |
-|      | 2 |      |                                        |      |      |
-|      | 2 |      |                                        |      |      |
-+------+---+------+----------------------------------------+------+------+
-
-Sommaire
-
-[Maîtrise du document [2](#_Toc36009210)](#_Toc36009210)
-
-[Service Echange [11](#_Toc133218604)](#_Toc133218604)
-
-[Introduction et présentation du document
-[11](#introduction-et-présentation-du-document)](#introduction-et-présentation-du-document)
-
-[ Généralités [11](#généralités)](#généralités)
-
-[Terminologie [11](#terminologie)](#terminologie)
-
-[ Composants [11](#composants)](#composants)
-
-[ Propriétés [12](#propriétés)](#propriétés)
-
-[Mécanisme de communication
-[12](#mécanisme-de-communication)](#mécanisme-de-communication)
-
-[ Fonctionnement [12](#fonctionnement)](#fonctionnement)
-
-[Processus de communication
-[12](#processus-de-communication)](#processus-de-communication)
-
-[Schéma de communication :
-[13](#schéma-de-communication)](#schéma-de-communication)
-
-[Format des messages : [15](#_Toc114068297)](#_Toc114068297)
-
-[Normes à respecter lors de la constitution de messages :
-[15](#normes-à-respecter-lors-de-la-constitution-de-messages)](#normes-à-respecter-lors-de-la-constitution-de-messages)
-
-[Description des fonctions du service échange :
-[16](#_Toc114068299)](#_Toc114068299)
-
-[Messages Ressources Humaines
-[17](#messages-ressources-humaines)](#messages-ressources-humaines)
-
-[ Bulletins de salaire
-[17](#bulletins-de-salaire)](#bulletins-de-salaire)
-
-[Mise au coffre-fort Digiposte d'un bulletin de salaire
-[17](#mise-au-coffre-fort-digiposte-dun-bulletin-de-salaire)](#mise-au-coffre-fort-digiposte-dun-bulletin-de-salaire)
-
-[Messages Structures et nomenclatures
-[18](#messages-structures-et-nomenclatures)](#messages-structures-et-nomenclatures)
-
-[ Nomenclature : Utilisateur
-[18](#nomenclature-utilisateur)](#nomenclature-utilisateur)
-
-[Création d\'un Utilisateur
-[18](#création-dun-utilisateur)](#création-dun-utilisateur)
-
-[Modification d\'un Utilisateur [19](#_Toc114068306)](#_Toc114068306)
-
-[Suppression d\'un Utilisateur [20](#_Toc114068307)](#_Toc114068307)
-
-[ Structure : Etablissement juridique
-[21](#structure-etablissement-juridique)](#structure-etablissement-juridique)
-
-[Création ou modification d'un établissement juridique
-[21](#création-ou-modification-dun-établissement-juridique)](#création-ou-modification-dun-établissement-juridique)
-
-[Suppression d'un établissement juridique
-[22](#suppression-dun-établissement-juridique)](#suppression-dun-établissement-juridique)
-
-[ Structure : Etablissements géographiques
-[23](#structure-etablissements-géographiques)](#structure-etablissements-géographiques)
-
-[Création d'un établissement géographique
-[23](#création-dun-établissement-géographique)](#création-dun-établissement-géographique)
-
-[Modification d'un établissement géographique
-[24](#_Toc114068313)](#_Toc114068313)
-
-[Suppression d'un établissement géographique
-[24](#suppression-dun-établissement-géographique)](#suppression-dun-établissement-géographique)
-
-[ Structure : Bâtiment [25](#structure-bâtiment)](#structure-bâtiment)
-
-[Création d\'un bâtiment
-[25](#création-dun-bâtiment)](#création-dun-bâtiment)
-
-[Modification d\'un bâtiment
-[25](#modification-dun-bâtiment)](#modification-dun-bâtiment)
-
-[Suppression d\'un bâtiment
-[26](#suppression-dun-bâtiment)](#suppression-dun-bâtiment)
-
-[ Structure : Etage [27](#structure-etage)](#structure-etage)
-
-[Création d\'un étage [27](#création-dun-étage)](#création-dun-étage)
-
-[Modification d\'un étage
-[27](#modification-dun-étage)](#modification-dun-étage)
-
-[Suppression d\'un étage
-[28](#suppression-dun-étage)](#suppression-dun-étage)
-
-[ Structure : Pièces [29](#structure-pièces)](#structure-pièces)
-
-[Création d\'une pièce [29](#création-dune-pièce)](#création-dune-pièce)
-
-[Modification d\'une pièce
-[30](#modification-dune-pièce)](#modification-dune-pièce)
-
-[Suppression d\'une pièce
-[31](#suppression-dune-pièce)](#suppression-dune-pièce)
-
-[ Structure : Pièces/UF [32](#structure-piècesuf)](#structure-piècesuf)
-
-[Création d\'un lien Pièce/UF
-[32](#création-dun-lien-pièceuf)](#création-dun-lien-pièceuf)
-
-[Modification d\'un lien Pièce/UF
-[33](#modification-dun-lien-pièceuf)](#modification-dun-lien-pièceuf)
-
-[Suppression Pièces/UF
-[34](#suppression-piècesuf)](#suppression-piècesuf)
-
-[ Structure : Lit [35](#structure-lit)](#structure-lit)
-
-[Création d\'un lit [35](#création-dun-lit)](#création-dun-lit)
-
-[Modification d\'un lit
-[36](#modification-dun-lit)](#modification-dun-lit)
-
-[Suppression d\'un lit [37](#suppression-dun-lit)](#suppression-dun-lit)
-
-[ Structure Box [38](#structure-box)](#structure-box)
-
-[ Structure Zone [39](#structure-zone)](#structure-zone)
-
-[ Structure Secteur [39](#structure-secteur)](#structure-secteur)
-
-[ Structure : Services [40](#structure-services)](#structure-services)
-
-[Création d\'un service
-[40](#création-dun-service)](#création-dun-service)
-
-[Modification d\'un service
-[40](#modification-dun-service)](#modification-dun-service)
-
-[Suppression d\'un service
-[42](#suppression-dun-service)](#suppression-dun-service)
-
-[ Structure : Unités fonctionnelles
-[43](#structure-unités-fonctionnelles)](#structure-unités-fonctionnelles)
-
-[Création d\'une Unité fonctionnelle (UF)
-[43](#création-dune-unité-fonctionnelle-uf)](#création-dune-unité-fonctionnelle-uf)
-
-[Modification d\'une Unité fonctionnelle (UF)
-[45](#modification-dune-unité-fonctionnelle-uf)](#modification-dune-unité-fonctionnelle-uf)
-
-[Mise hors service d\'une Unité fonctionnelle (UF)
-[46](#mise-hors-service-dune-unité-fonctionnelle-uf)](#mise-hors-service-dune-unité-fonctionnelle-uf)
-
-[ Structure : Centres de responsabilité
-[47](#structure-centres-de-responsabilité)](#structure-centres-de-responsabilité)
-
-[Création d'un centre de responsabilité
-[47](#création-dun-centre-de-responsabilité)](#création-dun-centre-de-responsabilité)
-
-[Modification d'un centre de responsabilité
-[47](#modification-dun-centre-de-responsabilité)](#modification-dun-centre-de-responsabilité)
-
-[Mise hors service d'un centre de responsabilité
-[49](#mise-hors-service-dun-centre-de-responsabilité)](#mise-hors-service-dun-centre-de-responsabilité)
-
-[ Nomenclature : Civilités
-[50](#nomenclature-civilités)](#nomenclature-civilités)
-
-[Création d'une civilité
-[50](#création-dune-civilité)](#création-dune-civilité)
-
-[Modification d'une civilité
-[50](#modification-dune-civilité)](#modification-dune-civilité)
-
-[Mise hors service d'une civilité
-[52](#mise-hors-service-dune-civilité)](#mise-hors-service-dune-civilité)
-
-[Mise hors service d'une version
-[52](#mise-hors-service-dune-version)](#mise-hors-service-dune-version)
-
-[ Nomenclature : Situations Familiales
-[53](#nomenclature-situations-familiales)](#nomenclature-situations-familiales)
-
-[Création d'une situation familiale
-[53](#création-dune-situation-familiale)](#création-dune-situation-familiale)
-
-[Modification d'une situation familiale
-[53](#modification-dune-situation-familiale)](#modification-dune-situation-familiale)
-
-[Mise hors service d'une situation familiale
-[54](#mise-hors-service-dune-situation-familiale)](#mise-hors-service-dune-situation-familiale)
-
-[Mise hors service d'une version
-[54](#mise-hors-service-dune-version-1)](#mise-hors-service-dune-version-1)
-
-[ Nomenclature : Nationalité
-[55](#nomenclature-nationalité)](#nomenclature-nationalité)
-
-[Création d'une nationalité
-[55](#création-dune-nationalité)](#création-dune-nationalité)
-
-[Modification d'une nationalité
-[55](#modification-dune-nationalité)](#modification-dune-nationalité)
-
-[Mise hors service d'une nationalité
-[56](#mise-hors-service-dune-nationalité)](#mise-hors-service-dune-nationalité)
-
-[Mise hors service d'une version
-[56](#mise-hors-service-dune-version-2)](#mise-hors-service-dune-version-2)
-
-[ Nomenclature : Pays [57](#nomenclature-pays)](#nomenclature-pays)
-
-[Création d'un pays [57](#création-dun-pays)](#création-dun-pays)
-
-[Modification d'un pays
-[57](#modification-dun-pays)](#modification-dun-pays)
-
-[Mise hors service d'un pays
-[59](#mise-hors-service-dun-pays)](#mise-hors-service-dun-pays)
-
-[Mise hors service d'une version
-[59](#mise-hors-service-dune-version-3)](#mise-hors-service-dune-version-3)
-
-[ Nomenclature : Spécialités Médicales
-[60](#nomenclature-spécialités-médicales)](#nomenclature-spécialités-médicales)
-
-[Création d'une spécialité médicale
-[60](#création-dune-spécialité-médicale)](#création-dune-spécialité-médicale)
-
-[Modification d'une spécialité médicale
-[60](#modification-dune-spécialité-médicale)](#modification-dune-spécialité-médicale)
-
-[Mise hors service d'une spécialité médicale
-[62](#mise-hors-service-dune-spécialité-médicale)](#mise-hors-service-dune-spécialité-médicale)
-
-[Mise hors service d'une version de spécialités médicales
-[62](#mise-hors-service-dune-version-de-spécialités-médicales)](#mise-hors-service-dune-version-de-spécialités-médicales)
-
-[ Nomenclature : Langues Maternelles
-[63](#nomenclature-langues-maternelles)](#nomenclature-langues-maternelles)
-
-[Création d'une langue maternelle
-[63](#création-dune-langue-maternelle)](#création-dune-langue-maternelle)
-
-[Modification d'une langue maternelle
-[63](#modification-dune-langue-maternelle)](#modification-dune-langue-maternelle)
-
-[Mise hors service d'une langue maternelle
-[64](#mise-hors-service-dune-langue-maternelle)](#mise-hors-service-dune-langue-maternelle)
-
-[Mise hors service d'une version de langue maternelle
-[64](#mise-hors-service-dune-version-de-langue-maternelle)](#mise-hors-service-dune-version-de-langue-maternelle)
-
-[ Nomenclature : Pièces justificatives
-[65](#nomenclature-pièces-justificatives)](#nomenclature-pièces-justificatives)
-
-[Création d'une pièce justificative
-[65](#création-dune-pièce-justificative)](#création-dune-pièce-justificative)
-
-[Modification d'une pièce justificative
-[65](#modification-dune-pièce-justificative)](#modification-dune-pièce-justificative)
-
-[Mise hors service d'une pièce justificative
-[66](#_Toc114068383)](#_Toc114068383)
-
-[Mise hors service d'une version des pièces justificatives
-[66](#mise-hors-service-dune-version-des-pièces-justificatives)](#mise-hors-service-dune-version-des-pièces-justificatives)
-
-[ Nomenclature : Catégories Socioprofessionnelles
-[67](#nomenclature-catégories-socioprofessionnelles)](#nomenclature-catégories-socioprofessionnelles)
-
-[Création d'une catégorie socioprofessionnelle
-[67](#création-dune-catégorie-socioprofessionnelle)](#création-dune-catégorie-socioprofessionnelle)
-
-[Modification d'une catégorie socioprofessionnelle
-[67](#modification-dune-catégorie-socioprofessionnelle)](#modification-dune-catégorie-socioprofessionnelle)
-
-[Mise hors service d'une catégorie socioprofessionnelle
-[68](#mise-hors-service-dune-catégorie-socioprofessionnelle)](#mise-hors-service-dune-catégorie-socioprofessionnelle)
-
-[Mise hors service d'une version des catégories socioprofessionnelles
-[68](#mise-hors-service-dune-version-des-catégories-socioprofessionnelles)](#mise-hors-service-dune-version-des-catégories-socioprofessionnelles)
-
-[ Nomenclature : Situations Professionnelles
-[69](#nomenclature-situations-professionnelles)](#nomenclature-situations-professionnelles)
-
-[Création d'une situation professionnelle
-[69](#création-dune-situation-professionnelle)](#création-dune-situation-professionnelle)
-
-[Modification d'une situation professionnelle
-[69](#modification-dune-situation-professionnelle)](#modification-dune-situation-professionnelle)
-
-[Mise hors service d'une situation professionnelle
-[70](#mise-hors-service-dune-situation-professionnelle)](#mise-hors-service-dune-situation-professionnelle)
-
-[Mise hors service d'une version des situations professionnelles
-[70](#mise-hors-service-dune-version-des-situations-professionnelles)](#mise-hors-service-dune-version-des-situations-professionnelles)
-
-[ Nomenclature : Statuts de parcours
-[71](#nomenclature-statuts-de-parcours)](#nomenclature-statuts-de-parcours)
-
-[Création d'un statut de parcours
-[71](#création-dun-statut-de-parcours)](#création-dun-statut-de-parcours)
-
-[Modification d'un statut de parcours
-[72](#modification-dun-statut-de-parcours)](#modification-dun-statut-de-parcours)
-
-[Mise hors service d'un statut de parcours
-[72](#mise-hors-service-dun-statut-de-parcours)](#mise-hors-service-dun-statut-de-parcours)
-
-[Mise hors service d'une version des statuts de parcours
-[73](#mise-hors-service-dune-version-des-statuts-de-parcours)](#mise-hors-service-dune-version-des-statuts-de-parcours)
-
-[ Nomenclature : Praticiens
-[73](#nomenclature-praticiens)](#nomenclature-praticiens)
-
-[Création d'un praticien
-[73](#création-dun-praticien)](#création-dun-praticien)
-
-[Modification d'un praticien
-[75](#modification-dun-praticien)](#modification-dun-praticien)
-
-[Suppression d'un praticien
-[76](#suppression-dun-praticien)](#suppression-dun-praticien)
-
-[ Nomenclature : Organismes
-[78](#nomenclature-organismes)](#nomenclature-organismes)
-
-[Création d'un organisme
-[78](#création-dun-organisme)](#création-dun-organisme)
-
-[Modification d'un organisme
-[80](#modification-dun-organisme)](#modification-dun-organisme)
-
-[Suppression d'un organisme
-[82](#suppression-dun-organisme)](#suppression-dun-organisme)
-
-[ Nomenclature : Gestion des contrats
-[84](#nomenclature-gestion-des-contrats)](#nomenclature-gestion-des-contrats)
-
-[Création d'un contrat
-[84](#création-dun-contrat)](#création-dun-contrat)
-
-[Modification d'un contrat
-[85](#modification-dun-contrat)](#modification-dun-contrat)
-
-[Suppression d'un contrat
-[88](#suppression-dun-contrat)](#suppression-dun-contrat)
-
-[ Nomenclature : Produits
-[90](#nomenclature-produits)](#nomenclature-produits)
-
-[Création d'un Produit :
-[90](#création-dun-produit)](#création-dun-produit)
-
-[ Modification sur produit
-[98](#modification-sur-produit)](#modification-sur-produit)
-
-[ Suppression d\'un produit
-[98](#suppression-dun-produit)](#suppression-dun-produit)
-
-[ Nomenclature : Fournisseurs :
-[99](#nomenclature-fournisseurs)](#nomenclature-fournisseurs)
-
-[ Création / Modification / Suppression d\'un fournisseur
-[99](#création-modification-suppression-dun-fournisseur)](#création-modification-suppression-dun-fournisseur)
-
-[ Modification Fournisseurs
-[101](#modification-fournisseurs)](#modification-fournisseurs)
-
-[ Suppression fournisseur :
-[103](#suppression-fournisseur)](#suppression-fournisseur)
-
-[ Nomenclature : Liens Produits / Fournisseurs :
-[104](#nomenclature-liens-produits-fournisseurs)](#nomenclature-liens-produits-fournisseurs)
-
-[Création / Modification / Suppression d\'un lien
-[104](#création-modification-suppression-dun-lien)](#création-modification-suppression-dun-lien)
-
-[Messages Patient [105](#messages-patient)](#messages-patient)
-
-[ Serveur d\'Identité, Mouvements, Actes :
-[105](#serveur-didentité-mouvements-actes)](#serveur-didentité-mouvements-actes)
-
-[Création / Modification / Suppression d\'Identité Patient (ID M1)
-[105](#création-modification-suppression-didentité-patient-id-m1)](#création-modification-suppression-didentité-patient-id-m1)
-
-[Création / Modification / Suppression d'un médecin traitant d'un
-patient (ID MT)
-[109](#création-modification-suppression-dun-médecin-traitant-dun-patient-id-mt)](#création-modification-suppression-dun-médecin-traitant-dun-patient-id-mt)
-
-[Création / Modification du consentement éclairé d'un patient (ID CE)
-[111](#création-modification-du-consentement-éclairé-dun-patient-id-ce)](#création-modification-du-consentement-éclairé-dun-patient-id-ce)
-
-[MPI (ID M5) [113](#_Toc114068427)](#_Toc114068427)
-
-[Message M1 IY : descriptions des informations psy (Nouveau message
-version c.06) [114](#_Toc114068428)](#_Toc114068428)
-
-[Admission d\'un Patient (M2) [115](#_Toc114068429)](#_Toc114068429)
-
-[Changement de Statut du Séjour (M3)
-[118](#changement-de-statut-du-séjour-m3)](#changement-de-statut-du-séjour-m3)
-
-[Changement de Rattachement du Séjour (M4)
-[120](#_Toc114068431)](#_Toc114068431)
-
-[Entrée du Patient dans l\'Unité de Soins (M6)
-[121](#_Toc114068432)](#_Toc114068432)
-
-[Changement des Conditions de Séjour du Patient (M7)
-[123](#changement-des-conditions-de-séjour-du-patient-m7)](#changement-des-conditions-de-séjour-du-patient-m7)
-
-[Sortie du Patient de l\'Unité de Soins (M8)
-[125](#_Toc114068434)](#_Toc114068434)
-
-[Sortie du Patient de l\'Hôpital (M9)
-[126](#sortie-du-patient-de-lhôpital-m9)](#sortie-du-patient-de-lhôpital-m9)
-
-[Couverture d'un patient (CV\|M1)
-[128](#couverture-dun-patient-cvm1)](#couverture-dun-patient-cvm1)
-
-[Libération de lit pour les séances (MV\|L1)
-[131](#libération-de-lit-pour-les-séances-mvl1)](#libération-de-lit-pour-les-séances-mvl1)
-
-[Libération de lit pour les venues (MV\|L1)
-[133](#libération-de-lit-pour-les-venues-mvl1)](#libération-de-lit-pour-les-venues-mvl1)
-
-[ [134](#section-15)](#section-15)
-
-[Libération de fin de consultation externe (MV\|FX)
-[135](#libération-de-fin-de-consultation-externe-mvfx)](#libération-de-fin-de-consultation-externe-mvfx)
-
-[ Messages mouvements d'urgence
-[137](#messages-mouvements-durgence)](#messages-mouvements-durgence)
-
-[Mouvements de box B1
-[137](#mouvements-de-box-b1)](#mouvements-de-box-b1)
-
-[ Mouvements temporaires aux urgences MT
-[139](#mouvements-temporaires-aux-urgences-mt)](#mouvements-temporaires-aux-urgences-mt)
-
-[Message M6 (Arrivée dans un emplacement temporaire)
-[139](#message-m6-arrivée-dans-un-emplacement-temporaire)](#message-m6-arrivée-dans-un-emplacement-temporaire)
-
-[Message M8 (sortie d'un emplacement temporaire)
-[142](#message-m8-sortie-dun-emplacement-temporaire)](#message-m8-sortie-dun-emplacement-temporaire)
-
-[ Actes [145](#actes)](#actes)
-
-[Message d'envoi de la codification NGAP (Actes)
-[145](#message-denvoi-de-la-codification-ngap-actes)](#message-denvoi-de-la-codification-ngap-actes)
-
-[Messages d'envoi de la codification CDAM (Actes)
-[147](#_Toc114068448)](#_Toc114068448)
-
-[ Examens [148](#examens)](#examens)
-
-[Demande d\'Examen (A1) [148](#demande-dexamen-a1)](#demande-dexamen-a1)
-
-[Messages Ressources Economiques et Financières
-[149](#messages-ressources-economiques-et-financières)](#messages-ressources-economiques-et-financières)
-
-[ Marchés : [149](#marchés)](#marchés)
-
-[Création d'un marché dans ELITE.S
-[149](#création-dun-marché-dans-elite.s)](#création-dun-marché-dans-elite.s)
-
-[ Transmission des consommations des produits
-[152](#transmission-des-consommations-des-produits)](#transmission-des-consommations-des-produits)
-
-[ Marchés validés dans ELITE.S:
-[154](#marchés-validés-dans-elite.s)](#marchés-validés-dans-elite.s)
-
-[Création d'un marché [154](#création-dun-marché)](#création-dun-marché)
-
-[ Modification de Marché
-[156](#modification-de-marché)](#modification-de-marché)
-
-[ Suppression De Marché :
-[157](#suppression-de-marché)](#suppression-de-marché)
-
-[ Demandes d'approvisionnements :
-[158](#demandes-dapprovisionnements)](#demandes-dapprovisionnements)
-
-[Création d'une demande
-[158](#création-dune-demande)](#création-dune-demande)
-
-[ Commandes : [162](#commandes)](#commandes)
-
-[Création d'une commande
-[162](#création-dune-commande)](#création-dune-commande)
-
-[ Modification de Commande
-[164](#modification-de-commande)](#modification-de-commande)
-
-[ Suppression de Commande :
-[165](#suppression-de-commande)](#suppression-de-commande)
-
-[ Livraisons provenant de l'extérieur :
-[166](#livraisons-provenant-de-lextérieur)](#livraisons-provenant-de-lextérieur)
-
-[Création d'une livraison externe
-[166](#création-dune-livraison-externe)](#création-dune-livraison-externe)
-
-[ Modification de lignes de Livraison
-[168](#modification-de-lignes-de-livraison)](#modification-de-lignes-de-livraison)
-
-[ Réceptions : [169](#réceptions)](#réceptions)
-
-[Création d'une réception
-[169](#création-dune-réception)](#création-dune-réception)
-
-[ Modification de Réception
-[171](#modification-de-réception)](#modification-de-réception)
-
-[ Suppression de Réception :
-[171](#suppression-de-réception)](#suppression-de-réception)
-
-[ Factures Externes : [172](#factures-externes)](#factures-externes)
-
-[Création d'une facture externe
-[172](#création-dune-facture-externe)](#création-dune-facture-externe)
-
-[ Mouvements de stocks internes:
-[176](#mouvements-de-stocks-internes)](#mouvements-de-stocks-internes)
-
-[Création d'un Mouvement de stock interne
-[176](#création-dun-mouvement-de-stock-interne)](#création-dun-mouvement-de-stock-interne)
-
-[ Envoi des liste pré établies
-[178](#envoi-des-liste-pré-établies)](#envoi-des-liste-pré-établies)
-
-[ Recettes diverses: [179](#recettes-diverses)](#recettes-diverses)
-
-[Création d'un Mouvement de recettes diverses
-[179](#création-dun-mouvement-de-recettes-diverses)](#création-dun-mouvement-de-recettes-diverses)
-
-[ Inventaires pour les biens immobilisés:
-[182](#inventaires-pour-les-biens-immobilisés)](#inventaires-pour-les-biens-immobilisés)
-
-[Création d'un Mouvement d'inventaire
-[182](#création-dun-mouvement-dinventaire)](#création-dun-mouvement-dinventaire)
-
-[Exemples d'évènements et messages associés :
-[183](#exemples-dévènements-et-messages-associés)](#exemples-dévènements-et-messages-associés)
-
-[Arrivée aux urgences :
-[183](#arrivée-aux-urgences)](#arrivée-aux-urgences)
-
-[Hospitalisation suite urgence :
-[183](#hospitalisation-suite-urgence)](#hospitalisation-suite-urgence)
-
-[Confirmation de suite hospitalisation :
-[183](#confirmation-de-suite-hospitalisation)](#confirmation-de-suite-hospitalisation)
-
-[Consultation externe suite urgence :
-[183](#consultation-externe-suite-urgence)](#consultation-externe-suite-urgence)
-
-[Confirmation de suite consultation :
-[183](#confirmation-de-suite-consultation)](#confirmation-de-suite-consultation)
-
-[Autres suites urgence
-[183](#autres-suites-urgence)](#autres-suites-urgence)
-
-[Entrée directe [185](#entrée-directe)](#entrée-directe)
-
-[Mutation après une entrée directe
-[185](#mutation-après-une-entrée-directe)](#mutation-après-une-entrée-directe)
-
-[Mutation insérée entre deux mouvements
-[185](#mutation-insérée-entre-deux-mouvements)](#mutation-insérée-entre-deux-mouvements)
-
-[Sortie définitive [185](#sortie-définitive)](#sortie-définitive)
-
-[Pré admission [185](#pré-admission)](#pré-admission)
-
-[Confirmation d'une pré admission
-[185](#confirmation-dune-pré-admission)](#confirmation-dune-pré-admission)
-
-[Nouveau né hospitalisé :
-[185](#nouveau-né-hospitalisé)](#nouveau-né-hospitalisé)
-
-[Changement de chambre : [187](#_Toc114068495)](#_Toc114068495)
-
-[Suppression d'un dossier :
-[187](#suppression-dun-dossier)](#suppression-dun-dossier)
-
-[Suppression d'un patient avec n dossiers
-[187](#suppression-dun-patient-avec-n-dossiers)](#suppression-dun-patient-avec-n-dossiers)
-
-[Fusion de deux patients
-[187](#fusion-de-deux-patients)](#fusion-de-deux-patients)
-
-[ Admission aux urgences
-[187](#admission-aux-urgences)](#admission-aux-urgences)
-
-[Arrivée aux urgences sans localisation
-[187](#arrivée-aux-urgences-sans-localisation)](#arrivée-aux-urgences-sans-localisation)
-
-[Arrivée aux urgences et mis en salle d'attente
-[188](#arrivée-aux-urgences-et-mis-en-salle-dattente)](#arrivée-aux-urgences-et-mis-en-salle-dattente)
-
-[Arrivée aux urgences et mise en box
-[188](#arrivée-aux-urgences-et-mise-en-box)](#arrivée-aux-urgences-et-mise-en-box)
-
-[ Mouvements possibles aux urgences
-[188](#mouvements-possibles-aux-urgences)](#mouvements-possibles-aux-urgences)
-
-[Passage d'un BOX vers la radio
-[188](#passage-dun-box-vers-la-radio)](#passage-dun-box-vers-la-radio)
-
-[Changement de box [188](#changement-de-box)](#changement-de-box)
-
-[Retour au box suite à une radio
-[189](#retour-au-box-suite-à-une-radio)](#retour-au-box-suite-à-une-radio)
-
-[Passage de salle d'attente vers la radio
-[189](#passage-de-salle-dattente-vers-la-radio)](#passage-de-salle-dattente-vers-la-radio)
-
-[Passage de la radio vers le scanner
-[189](#passage-de-la-radio-vers-le-scanner)](#passage-de-la-radio-vers-le-scanner)
-
-[Le patient est dans un box suite Hospitalisation ou consultation
-externe
-[189](#le-patient-est-dans-un-box-suite-hospitalisation-ou-consultation-externe)](#le-patient-est-dans-un-box-suite-hospitalisation-ou-consultation-externe)
-
-[Le patient est dans un box il est hospitalisé en lit porte mais reste
-dans le box
-[189](#le-patient-est-dans-un-box-il-est-hospitalisé-en-lit-porte-mais-reste-dans-le-box)](#le-patient-est-dans-un-box-il-est-hospitalisé-en-lit-porte-mais-reste-dans-le-box)
-
-[Cas Particuliers de Demandes Faites aux Serveurs
-[192](#cas-particuliers-de-demandes-faites-aux-serveurs)](#cas-particuliers-de-demandes-faites-aux-serveurs)
-
-[ Serveur d\'Identité [192](#serveur-didentité)](#serveur-didentité)
-
-[ Serveur d\'Actes [194](#serveur-dactes)](#serveur-dactes)
-
-[Spécifications du Service Echange
-[195](#spécifications-du-service-echange)](#spécifications-du-service-echange)
-
-[ Schéma Fonctionnel [195](#schéma-fonctionnel)](#schéma-fonctionnel)
-
-[ Spécificités Fonctionnelles
-[195](#spécificités-fonctionnelles)](#spécificités-fonctionnelles)
-
-[Structure de l'accusé de réception
-[195](#structure-de-laccusé-de-réception)](#structure-de-laccusé-de-réception)
-
-[Informations à répercuter vers les autres applications
-[196](#informations-à-répercuter-vers-les-autres-applications)](#informations-à-répercuter-vers-les-autres-applications)
-
-[Structure des tables du Service Echange
-[196](#structure-des-tables-du-service-echange)](#structure-des-tables-du-service-echange)
-
-[ Composants Externes
-[196](#composants-externes)](#composants-externes)
-
-[Service de demande de création d\'IPP.
-[196](#service-de-demande-de-création-dipp.)](#service-de-demande-de-création-dipp.)
-
-[]{#_Toc133218604 .anchor}Service Echange
+> **Note technique** : ce document est une conversion automatique de la spécification Word officielle. Il sert de référence pour le skill `hpk-parser`.
 
 # Introduction et présentation du document
 
@@ -1641,7 +138,6 @@ Il existe deux type de processus :
 
 ### Schéma de communication :
 
-![](vertopal_d5b45b6900c449bd9cd55a0f4acdb4a7/media/image5.wmf)
 
 \
 
@@ -1719,7 +215,6 @@ n'est pas connue on aura :
 
 ...\|IPP_ATIENT\|NOM\|PRENOM\|\|\|D\|Mr\|...
 
-![](vertopal_d5b45b6900c449bd9cd55a0f4acdb4a7/media/image6.png)
 Attention
 
 Des champs peuvent être rajoutés par Symphonie *On Line* à la fin des
@@ -1731,14 +226,12 @@ uniquement sur les champs connus.
 
 ### Description des fonctions du service échange :
 
--   ![](vertopal_d5b45b6900c449bd9cd55a0f4acdb4a7/media/image1.png)
     ENVOI :\
     Cette fonction traite les messages en provenance d'HEXAGONE et à
     destination des applications externes. Elle stocke le message reçu
     dans la table des messages en attente et envoie un accusé de
     réception à HEXAGONE
 
--   ![](vertopal_d5b45b6900c449bd9cd55a0f4acdb4a7/media/image1.png)
     RECEPTION :\
     Cette fonction traite les messages en provenance des applications
     externes et à destination d'HEXAGONE. Elle stocke le message reçu
@@ -1746,12 +239,11 @@ uniquement sur les champs connus.
     réception à l'application externe expéditrice, avec les informations
     clés nécessaire (N° IPP, par exemple).
 
--   ![](vertopal_d5b45b6900c449bd9cd55a0f4acdb4a7/media/image1.png)
     ACCUSE DE RECEPTION :\
     Cet accusé de réception du Service Echange consiste en trois
     paramètres.
 
-> ![](vertopal_d5b45b6900c449bd9cd55a0f4acdb4a7/media/image2.png) Prend
+> Prend
 > les valeurs :
 >
 > 0 Reçu et pris en charge par le Service Echange.
@@ -1762,18 +254,16 @@ uniquement sur les champs connus.
 
 > 50 Problème mais demande de ré-envoi
 >
-> ![](vertopal_d5b45b6900c449bd9cd55a0f4acdb4a7/media/image2.png) Statut
+> Statut
 >
-> ![](vertopal_d5b45b6900c449bd9cd55a0f4acdb4a7/media/image2.png)
 > Contexte de l'erreur survenue dans le Service Echange. Cette erreur
 > pourra ou non être traitée par l'application qui a envoyé le message.
 > Dans tous les cas, un fichier texte (d\'extension .log) sera alimenté
 > lors de la détection d'une erreur par le Service Echange.
 
--   ![](vertopal_d5b45b6900c449bd9cd55a0f4acdb4a7/media/image1.png)
     MOTEUR DE GESTION DES MESSAGES :
 
-> ![](vertopal_d5b45b6900c449bd9cd55a0f4acdb4a7/media/image2.png) Cette
+> Cette
 > fonction consiste en une application autonome qui tourne en
 > permanence, qui scrute la table des messages en attente dans l'ordre
 > chronologique d'émission, qui génère par destinataire les messages
@@ -1781,7 +271,7 @@ uniquement sur les champs connus.
 > message. Ensuite il supprime ou tope "à traiter" (suivant paramétrage)
 > les messages dans la table des messages en attente.
 >
-> ![](vertopal_d5b45b6900c449bd9cd55a0f4acdb4a7/media/image2.png) Le
+> Le
 > moteur essaiera de traiter toutes les demandes qu'il recevra. Dans le
 > cas où il ne pourrait pas lancer le composant paramétré comme
 > destinataire, le message sera laissé en attente, ou la communication
@@ -1794,7 +284,7 @@ uniquement sur les champs connus.
 > d'entrée dans une unité de soin si le message M1 de création du
 > patient n'a pu être traité par cette même application.
 >
-> ![](vertopal_d5b45b6900c449bd9cd55a0f4acdb4a7/media/image2.png) Dans
+> Dans
 > le cas d\'envoi d\'informations au Service Echange (retour), il n'est
 > pas nécessaire d'avoir le composant du destinataire sur tous les
 > postes. Par contre, il peut être intéressant, pour des questions de
@@ -1803,7 +293,7 @@ uniquement sur les champs connus.
 > fonctionnent que dans un environnement *Windows*. Si ce n\'est pas le
 > cas, les composants sont directement activés depuis le serveur.
 >
-> ![](vertopal_d5b45b6900c449bd9cd55a0f4acdb4a7/media/image2.png) Le
+> Le
 > run-time HEXAGONE doit être déployé sur tous les postes des
 > applications communicantes s'il n'y a pas de poste dédié à la
 > communication. Et aux seuls postes faisant des demandes au serveur
@@ -11841,7 +10331,7 @@ Evènements déclenchant l'émission de ce message:
 | es/venues** | ** |           |     |                               |
 +-------------+----+-----------+-----+-------------------------------+
 
-##  {#section-14 .list-paragraph}
+##
 
 ### Libération de lit pour les venues (MV\|L1)
 
@@ -12069,7 +10559,6 @@ Evènements déclenchant l'émission de ce message:
 | es/venues** | ** |           |     |                               |
 +-------------+----+-----------+-----+-------------------------------+
 
-## 
 
 ###  Libération de fin de consultation externe (MV\|FX)
 
@@ -12320,13 +10809,12 @@ plateaux techniques, salles d'attentes ...) et définitives (Box).
 
 Un seul message MU / B1 envoyé pour identifier les évènements suivants :
 
-![](vertopal_d5b45b6900c449bd9cd55a0f4acdb4a7/media/image1.png) Arrivée
+Arrivée
 aux urgences et mise en box directe
 
-![](vertopal_d5b45b6900c449bd9cd55a0f4acdb4a7/media/image1.png)
 Changement de box (passage d'un box à un autre)
 
-![](vertopal_d5b45b6900c449bd9cd55a0f4acdb4a7/media/image1.png) Sortie
+Sortie
 des urgences si le patient était dans un box.
 
 +-------------+----+-----------+-----+-------------------------------+
@@ -12485,15 +10973,14 @@ des urgences si le patient était dans un box.
 Trois messages distincts sont envoyés pour identifier les évènements
 suivants :
 
-![](vertopal_d5b45b6900c449bd9cd55a0f4acdb4a7/media/image1.png) Départ
+Départ
 d'un emplacement temporaire, quelque soit l'emplacement de destination
 même un Box.
 
-![](vertopal_d5b45b6900c449bd9cd55a0f4acdb4a7/media/image1.png) Arrivée
+Arrivée
 dans un emplacement temporaire, quelque soit l'emplacement de départ
 même un Box.
 
-![](vertopal_d5b45b6900c449bd9cd55a0f4acdb4a7/media/image1.png)
 Changement d'emplacement temporaire.
 
 ### Message M6 (Arrivée dans un emplacement temporaire)
@@ -13150,7 +11637,6 @@ codification *CDAM*.
 |             | ** |           |     |                               |
 +-------------+----+-----------+-----+-------------------------------+
 
-![](vertopal_d5b45b6900c449bd9cd55a0f4acdb4a7/media/image6.png)
 Attention
 
 Lors de la mise en œuvre de la *CCAM*, un nouveau message K3 sera mis en
@@ -14816,12 +13302,12 @@ prendre en compte.
 Pour une remise à zéro d'une ligne mettre la quantité à zéro. Attention
 au code' ligne de commande soldée'
 
--   ![](vertopal_d5b45b6900c449bd9cd55a0f4acdb4a7/media/image1.png) Si
+-   Si
     code = O la ligne de commande sera considérée dans GREF comme soldée
     en livraison et donc ne pourra plus être associée a une autre
     réception.
 
--   ![](vertopal_d5b45b6900c449bd9cd55a0f4acdb4a7/media/image1.png) Si
+-   Si
     code = N La ligne de commande reste en attente de livraison pour la
     différence entre la quantité commandée et le cumul des quantités
     livrées (si ce cumul est inférieur à la quantité en commande).
@@ -15395,7 +13881,6 @@ corrects.
 | évisible** |    |      |     |                                       |
 +------------+----+------+-----+---------------------------------------+
 
-![](vertopal_d5b45b6900c449bd9cd55a0f4acdb4a7/media/image6.png)
 Attention
 
 Toutes les factures transmises et générées dans ELITE.S ne pourront pas
@@ -15414,14 +13899,14 @@ les contrôles sont corrects.
 ***Ces messages concernent uniquement les produits gérés en stock et non
 gérés en entrées/sorties simultanées:***
 
-> ![](vertopal_d5b45b6900c449bd9cd55a0f4acdb4a7/media/image2.png) **Les
+> **Les
 > sorties de stock classiques des magasins et / ou armoires de service
 >  :**
 >
 > Consommations de produits par les services, et gestion des retours de
 > service. Dans ce cas, 2 possibilités sont offertes :
 
--   ![](vertopal_d5b45b6900c449bd9cd55a0f4acdb4a7/media/image1.png) Soit
+-   Soit
     > les mouvements transmis sont déjà valorisés par le système
     > émetteur, dans ce cas la valorisation du mouvement sera
     > comptabilisée telle quelle dans ELITE.S . L'intégration de ce
@@ -15429,7 +13914,7 @@ gérés en entrées/sorties simultanées:***
     > *(Message de type SO, code Message S1 avec champ Valeur de la
     > sortie renseignée)*
 
--   ![](vertopal_d5b45b6900c449bd9cd55a0f4acdb4a7/media/image1.png) Soit
+-   Soit
     > les mouvements transmis sont uniquement quantitatifs, dans ce cas
     > la valorisation sera effectuée dans ELITE.S lors de l'arrêté de
     > balance définitive : L'intégration de ces mouvements génère des
@@ -15437,7 +13922,7 @@ gérés en entrées/sorties simultanées:***
     > *(Message de type SO, code Message S1 avec champ Valeur de la
     > sortie non renseignée)*
 
-> ![](vertopal_d5b45b6900c449bd9cd55a0f4acdb4a7/media/image2.png) **Les
+> **Les
 > inventaires de stock par magasin et / ou armoire de service:**
 >
 > Ces mouvements permettront de générer un état d'inventaire qui sera
@@ -15447,7 +13932,7 @@ gérés en entrées/sorties simultanées:***
 > *(Message de type SO, code Message I1 avec champ Valeur de la sortie
 > non renseignée)*
 >
-> ![](vertopal_d5b45b6900c449bd9cd55a0f4acdb4a7/media/image2.png) **Les
+> **Les
 > transferts entre magasins de l 'établissement**
 >
 > Ces mouvements permettront de gérer dans ELITE.S les mouvements entre
@@ -16583,7 +15068,6 @@ Ils devront avoir le format suivant:
 
 -   ## Schéma Fonctionnel
 
-![](vertopal_d5b45b6900c449bd9cd55a0f4acdb4a7/media/image7.wmf)
 
 -   ## Spécificités Fonctionnelles
 

--- a/docs/hpk-parser.md
+++ b/docs/hpk-parser.md
@@ -1,40 +1,40 @@
 # hpk-parser
 
-Parsing et explication des messages HPK (Healthcare Protocol Kernel). Format proprietaire pipe-delimited utilise dans les SIH francais (Hexagone).
+Parsing et explication des messages HPK (Healthcare Protocol Kernel). Format propriétaire pipe-delimited utilisé dans les SIH français (Hexagone).
 
 ## Quand utiliser ce skill
 
 - Comprendre le contenu d'un message HPK
-- Deboguer des problemes de donnees ou d'integration
+- Déboguer des problèmes de données ou d'intégration
 - Valider la structure et les champs d'un message
 - Documenter des exemples de messages HPK
 
 ## Ce que fait le skill
 
 - **Parse** les messages HPK et identifie le type
-- **Extrait** tous les champs avec leurs libelles
+- **Extrait** tous les champs avec leurs libellés
 - **Valide** la structure et les formats attendus
-- **Explique** le message en langage comprehensible
+- **Explique** le message en langage compréhensible
 - **Documente** les correspondances HPK vers HL7
 
-## Types de messages supportes
+## Types de messages supportés
 
-### Identite (ID|*)
+### Identité (ID|*)
 
 | Code | Description |
 |------|-------------|
-| **ID\|M1** | Donnees demographiques patient |
-| **ID\|MT** | Affectation du medecin traitant |
-| **ID\|CE** | Consentement eclaire |
+| **ID\|M1** | Données démographiques patient |
+| **ID\|MT** | Affectation du médecin traitant |
+| **ID\|CE** | Consentement éclairé |
 
 ### Mouvements (MV|*)
 
 | Code | Description |
 |------|-------------|
-| **MV\|M2** | Admission hospitaliere |
+| **MV\|M2** | Admission hospitalière |
 | **MV\|M3** | Changement de statut |
-| **MV\|M6** | Transfert d'unite/service |
-| **MV\|M8** | Sortie d'unite |
+| **MV\|M6** | Transfert d'unité/service |
+| **MV\|M8** | Sortie d'unité |
 | **MV\|M9** | Sortie d'hospitalisation |
 | **MV\|B1** | Mouvement box d'urgence |
 | **MV\|MT** | Mouvement temporaire (examen, acte) |
@@ -51,16 +51,16 @@ Approvisionnement (PR, FO, MA, CO, LI, RO, FA), inventaire (SO, IM), structure (
 
 ## Exemple d'utilisation
 
-**Message en entree** :
+**Message en entrée** :
 ```
 ID|M1|C|HEXAGONE|20260122120000|USER001|PAT12345|DUPONT|JEAN|19750315|M|15 RUE DE LA PAIX|75001|PARIS|FRA|0612345678||||||||||||||||||||||||||||||
 ```
 
-**Resultat** :
+**Résultat** :
 ```
-Type : Identite Patient (Donnees demographiques)
-Operation : Creation (nouvel enregistrement)
-Patient : JEAN DUPONT, ne le 15/03/1975, Masculin
+Type : Identité Patient (Données démographiques)
+Opération : Création (nouvel enregistrement)
+Patient : JEAN DUPONT, né le 15/03/1975, Masculin
 Contact : 06 12 34 56 78
 Adresse : 15 RUE DE LA PAIX, 75001 PARIS, France
 ```
@@ -70,34 +70,34 @@ Adresse : 15 RUE DE LA PAIX, 75001 PARIS, France
 Tous les messages HPK suivent cette structure de base :
 
 ```
-Type|Message|Mode|Emetteur|Date|User|[champs supplementaires...]
+Type|Message|Mode|Émetteur|Date|User|[champs supplémentaires...]
 ```
 
 | Champ | Description | Valeurs possibles |
 |-------|-------------|-------------------|
-| **Type** | Categorie de message | ID, MV, CV, PR, FO, MA, CO, LI, RO, FA, SO, IM, ST, UT, RD, DD |
+| **Type** | Catégorie de message | ID, MV, CV, PR, FO, MA, CO, LI, RO, FA, SO, IM, ST, UT, RD, DD |
 | **Message** | Code du message | M1, M2, M6, M9, MT, CE, B1, etc. |
-| **Mode** | Type d'operation | C (Creation), M (Modification), D (Suppression) |
-| **Emetteur** | Systeme source | Nom de l'application emettrice |
+| **Mode** | Type d'opération | C (Création), M (Modification), D (Suppression) |
+| **Émetteur** | Système source | Nom de l'application émettrice |
 | **Date** | Horodatage | Format `YYYYMMDDHHmmss` |
-| **User** | Identifiant utilisateur | ID de l'operateur |
+| **User** | Identifiant utilisateur | ID de l'opérateur |
 
 ## Correspondances HPK vers HL7
 
-Le format HPK est souvent mappe vers **HL7 v2.5** / **IHE PAM 2.10** :
+Le format HPK est souvent mappé vers **HL7 v2.5** / **IHE PAM 2.10** :
 
 | HPK | HL7 | Description |
 |-----|-----|-------------|
 | MV\|M2 | ADT^A01 | Admission |
 | MV\|M6 | ADT^A02 | Transfert |
 | MV\|M9 | ADT^A03 | Sortie |
-| ID\|M1 | ADT^A08 | Mise a jour identite |
+| ID\|M1 | ADT^A08 | Mise à jour identité |
 
-## References
+## Références
 
-- [Specification HPK ADT](./hpk-adt-message.md)
+- [Spécification HPK ADT](./hpk-adt-message.md)
 - [Guide des parsers healthcare](./healthcare-parsers-guide.md)
-- [SKILL.md](../skills/hpk-parser/SKILL.md) -- structures detaillees des champs
+- [SKILL.md](../skills/hpk-parser/SKILL.md) -- structures détaillées des champs
 
 ## Skills connexes
 

--- a/docs/issue-review.md
+++ b/docs/issue-review.md
@@ -1,0 +1,97 @@
+# Issue Review
+
+Revue autonome d'issues GitLab/GitHub par personas IA. Analyse multi-angle de la faisabilité, complétude, risques et architecture, avec publication automatique du rapport sur l'issue.
+
+## Quand l'utiliser
+
+- Vous voulez un avis structuré sur une issue avant de lancer l'implémentation
+- Vous voulez vérifier que l'issue est suffisamment bien définie, complète et réalisable
+- Vous voulez identifier les risques et les points techniques à considérer avant de coder
+
+## Différence avec les autres skills
+
+| | meeting | fast-meeting | issue-review |
+|---|---|---|---|
+| **Entrée** | Sujet libre | Sujet libre ou issue | Issue obligatoire (#ID ou URL) |
+| **Personas** | Sélection manuelle | Automatique | Automatique |
+| **Tours de réunion** | 3 tours | 1 tour + synthèse | 3 tours (positions, débat, convergence) |
+| **Validation utilisateur** | Obligatoire | Aucune | Aucune (sauf issue fermée) |
+| **Implémentation** | Après validation | Immédiate | Aucune — analytique uniquement |
+| **MR/PR** | Après validation | Automatique | Aucune |
+| **Commentaire issue** | Sur demande | Automatique (PO) | Automatique (PO + technique si pertinent) |
+| **Exploration codebase** | Non | Si code concerné | Systématique |
+
+## Comment l'utiliser
+
+Demandez simplement à votre agent IA de lancer une revue d'issue :
+
+```
+issue-review #42
+```
+
+```
+issue-review https://gitlab.example.com/group/project/-/issues/42
+```
+
+```
+issue-review https://github.com/org/repo/issues/15
+```
+
+## Ce que le skill fait
+
+1. **Récupère l'issue complète** — Titre, description, tous les commentaires, labels
+2. **Détecte le remote** — GitLab ou GitHub pour la publication du commentaire
+3. **Vérifie le contenu** — Si l'issue est trop vague, poste un commentaire listant les éléments manquants et s'arrête
+4. **Récupère le contexte lié** — Diff de la branche liée si elle existe
+5. **Explore le codebase** — Lit les fichiers et modules pertinents pour donner du contexte aux personas
+6. **Sélectionne 3-4 personas automatiquement** — Selon le domaine de l'issue
+7. **Anime une réunion en 3 tours** — Positions initiales, débat entre personas, convergence pondérée
+8. **Vérifie le consensus** — Lance un avocat du diable si toutes les personas sont d'accord
+9. **Produit une analyse structurée** — Faisabilité, complétude, risques, points techniques, prochaines étapes
+10. **Publie le rapport sur l'issue** — Commentaire en français, orienté PO/consultant avec points techniques si nécessaire
+
+## Personas disponibles
+
+| Persona | Rôle | Ce qui compte pour elle |
+|---------|------|------------------------|
+| SOLID Alex | Ingénieur Backend Senior | Qualité de code, maintenabilité |
+| Sprint Zero Sarah | Product Owner (PO) | Valeur utilisateur, rapidité de livraison |
+| Paranoid Shug | Ingénieur Sécurité (certifié OWASP) | Surface d'attaque, sécurité web |
+| Pipeline Mo | Ingénieur DevOps / SRE | Opérabilité, déploiement, scalabilité |
+| Pixel-Perfect Hugo | Ingénieur Frontend | Expérience utilisateur, Vue.js, React, PrimeVue |
+| Whiteboard Damien | Tech Lead / Architecte | Vision long terme, capacité de l'équipe |
+| Edge-Case Nico | Ingénieur QA | Testabilité, cas limites, Playwright, Vitest |
+| EXPLAIN PLAN Isabelle | Ingénieure Base de Données Senior (Oracle) | Administration Oracle, PL/SQL, tuning |
+| Schema JB | Ingénieur Data | Intégrité des données, migrations |
+| RFC Santiago | PO Interopérabilité Senior | Standards HL7, FHIR, HPK |
+| Legacy Larry | Développeur Fullstack Senior (Uniface) | Modernisation legacy, patterns 4GL/RAD |
+| HL7 Victor | Développeur Fullstack Interopérabilité Senior | Intégration bout-en-bout, parsing de messages |
+| RGPD Raphaël | DPO / Compliance | RGPD, HDS, consentement |
+| Dr. Workflow Wendy | Experte Domaine Santé | Workflows hospitaliers, administration patient |
+| Figma Fiona | Designer UX/UI | Recherche utilisateur, tokens de design, WCAG |
+| Dashboard Estelle | Senior BI / Data Analyst — Finance & Comptabilité | Reporting financier, KPIs, datatables complexes |
+
+La sélection est automatique selon le contenu et les labels de l'issue.
+
+## Garde-fous
+
+| Protection | Comportement |
+|---|---|
+| **Issue vide ou trop vague** | Poste un commentaire listant les éléments manquants, pas de réunion |
+| **Issue fermée** | Avertit l'utilisateur et demande confirmation avant de continuer |
+| **Consensus trop facile** | Lancement d'un avocat du diable si toutes les personas sont d'accord |
+| **Échec de publication** | Affiche le rapport dans la conversation + commande manuelle |
+
+## Verdicts possibles
+
+| Verdict | Signification |
+|---|---|
+| ✅ **Prête pour implémentation** | Issue bien définie, faisable, risques gérables |
+| ⚠️ **Nécessite des ajustements** | Faisable mais éléments manquants ou risques à mitiger |
+| ❌ **Nécessite une refonte significative** | Lacunes majeures, scope flou, préoccupations architecturales non résolues |
+
+## Exemple de résultat
+
+Le skill produit :
+- Une **analyse affichée** dans la conversation (contexte, participants, faisabilité, complétude, risques, points techniques, prochaines étapes, verdict)
+- Un **commentaire sur l'issue** en français, orienté PO/consultant avec points techniques si pertinent, incluant des prochaines étapes sous forme de checklist actionnable

--- a/docs/pdf.md
+++ b/docs/pdf.md
@@ -1,27 +1,27 @@
 # Documents PDF
 
-Manipulation complete de documents PDF : extraction, creation, fusion, decoupage et formulaires.
+Manipulation complète de documents PDF : extraction, création, fusion, découpage et formulaires.
 
 ## Contexte
 
-Ce skill couvre l'ensemble des operations sur les fichiers PDF. Il s'adresse aux equipes qui doivent extraire des donnees, generer des rapports ou manipuler des formulaires PDF.
+Ce skill couvre l'ensemble des opérations sur les fichiers PDF. Il s'adresse aux équipes qui doivent extraire des données, générer des rapports ou manipuler des formulaires PDF.
 
 ## Cas d'utilisation
 
 - **Extraire** du texte ou des tableaux depuis un PDF
-- **Creer** de nouveaux documents PDF
-- **Fusionner ou decouper** des PDF existants
+- **Créer** de nouveaux documents PDF
+- **Fusionner ou découper** des PDF existants
 - **Remplir** des formulaires PDF interactifs
 - **Convertir** des PDF en images
-- **Analyser** des PDF scannes via OCR (Optical Character Recognition)
+- **Analyser** des PDF scannés via OCR (Optical Character Recognition)
 
-## Librairies utilisees (section technique)
+## Librairies utilisées (section technique)
 
 | Librairie | Usage principal |
 |-----------|----------------|
-| **pypdf** | Lecture, fusion, decoupage, metadonnees |
-| **pdfplumber** | Extraction de texte et tableaux (recommande) |
-| **reportlab** | Creation de PDF depuis zero |
+| **pypdf** | Lecture, fusion, découpage, métadonnées |
+| **pdfplumber** | Extraction de texte et tableaux (recommandé) |
+| **reportlab** | Création de PDF depuis zéro |
 | **pdftotext / qpdf / pdftk** | Outils en ligne de commande |
 
 ## Exemples (section technique)
@@ -42,7 +42,7 @@ with pdfplumber.open("document.pdf") as pdf:
     tables = pdf.pages[0].extract_tables()
 ```
 
-### Creation de PDF
+### Création de PDF
 
 ```python
 from reportlab.pdfgen import canvas
@@ -55,7 +55,7 @@ c.save()
 
 | Script | Fonction |
 |--------|----------|
-| `check_fillable_fields.py` | Verifier les champs de formulaire |
+| `check_fillable_fields.py` | Vérifier les champs de formulaire |
 | `fill_fillable_fields.py` | Remplir les champs d'un formulaire |
 | `extract_form_field_info.py` | Extraire les informations des champs |
 | `convert_pdf_to_images.py` | Convertir les pages en images |
@@ -65,10 +65,10 @@ c.save()
 ```
 @workspace avec pdf, extrais le texte de ce document
 @workspace avec pdf, fusionne ces 3 PDF en un seul
-@workspace avec pdf, remplis ce formulaire avec les donnees du JSON
+@workspace avec pdf, remplis ce formulaire avec les données du JSON
 ```
 
-## Demarrage rapide
+## Démarrage rapide
 
 ```bash
 npx skills add Dedalus-ERP-PAS/foundation-skills --skill pdf -g -y
@@ -76,4 +76,4 @@ npx skills add Dedalus-ERP-PAS/foundation-skills --skill pdf -g -y
 
 ## Ressources
 
-- [SKILL.md complet](../skills/pdf/SKILL.md) — Guide detaille avec tous les workflows
+- [SKILL.md complet](../skills/pdf/SKILL.md) — Guide détaillé avec tous les workflows

--- a/docs/security-review.md
+++ b/docs/security-review.md
@@ -2,6 +2,13 @@
 
 Audit de sécurité couvrant l'authentification, l'injection SQL, l'exposition de secrets, CSRF (Cross-Site Request Forgery) et les vulnérabilités OWASP (Open Web Application Security Project) Top 10.
 
+## Pourquoi ce skill
+
+- **Données patients sensibles** — En milieu hospitalier, une faille expose des données de santé protégées par le RGPD et l'HDS
+- **Conformité réglementaire** — Les audits de sécurité réguliers sont exigés pour les hébergeurs de données de santé
+- **Prévention proactive** — Détecter les vulnérabilités avant la mise en production coûte 100x moins cher qu'après
+- **Couverture systématique** — Le skill vérifie 10 catégories OWASP en une seule passe, rien n'est oublié
+
 ## Quand utiliser ce skill
 
 Utilisez ce skill pour :

--- a/docs/specification-hpk-gef.md
+++ b/docs/specification-hpk-gef.md
@@ -1,157 +1,8 @@
-# Referentiel des messages HPK - Gestion Economique et Financiere (GEF)
+# Référentiel des messages HPK - Gestion Économique et Financière (GEF)
 
-Specification de reference des messages HPK pour la gestion economique et financiere dans Hexagone. Ce document decrit les formats de messages entrants et sortants (produits, fournisseurs, commandes, livraisons, etc.).
+Spécification de référence des messages HPK pour la gestion économique et financière dans Hexagone. Ce document decrit les formats de messages entrants et sortants (produits, fournisseurs, commandes, livraisons, etc.).
 
-> **Note technique** : ce document est une conversion automatique de la specification Word officielle. Il sert de reference pour le skill `hpk-parser`.
-
-## Historique des versions
-
-```
-Numéro de
-version
-```
-
-```
-Date Résumé Responsable
-```
-
-```
-09.04.224 21 /0 8 /2020 Référencement des messages gestion
-économique et financière entrants et
-sortants
-```
-
-```
-Dubos Stéphane
-```
-
-```
-09.04.225 25/05/2021 Modification des messages Marchés
-sortant.
-Modification des messages
-fournisseurs sortant.
-Ajout des messages d’échantillons et
-d’annulation de livraison
-```
-
-```
-Dubos Stéphane
-```
-
-```
-09.04.225- 2 17/10/2022 Ajout de l’IUD-ID
-Comptes sur 13 caractères
-Ajout du Franco de port dans les
-messages d’informations générales
-fournisseur
-Ajout du stock mensuel dans les
-messages de consommations
-```
-
-```
-Dubos Stéphane
-```
-
-```
-09.04.22 6 - 1 17/0 9 /2024 Ajout transitaire dans les messages
-DA|DE
-Ordonnancement des messages
-marchés et ajout des informations
-fournisseurs dans le MA|M2 et du
-marché dans le FP|M
-```
-
-```
-Dubos Stéphane
-```
-
-##### APPROBATIONS
-
-```
-Nom Fonction Date
-Scagliarini Laurence Cellule test et qualification
-Guillot Laëtitia P.O.O 19/10/
-```
-
-## TABLE OF CONTENTS
-
-- Introduction et présentation du document
-- 1 Mécanisme de communication
-  - ➢ Fonctionnement
-    - 1.1.1 Processus de communication
-    - 1.1.2 Format des messages
-    - 1.1.3 Normes à respecter lors de la constitution de messages
-- Produits
-- 2 Création d’un Produit
-  - ➢ Message 0 : Données générales du produit
-  - ➢ Message 1 : Informations produit pharmacie
-  - ➢ Message 2 : Informations pour édition livret thérapeutique
-  - ➢ Message 3 : Informations comptables pour Gestion Economique
-  - ➢ Message 4 : Informations générales pour Gestion Economique
-  - ➢ Message 5 : Informations sur les magasins par produit
-- 3 Modification sur produit
-- 4 Suppression d'un produit
-- Fournisseurs
-- 1 Création / Modification / Suppression d'un fournisseur
-  - ➢ Message 1 : Informations générales liées au fournisseur
-  - ➢ Message 2 : Domiciliations bancaires liées au fournisseur
-  - ➢ Message 3 : Points de commande liés au fournisseur
-- 2 Modification Fournisseurs
-- 3 Suppression fournisseur :
-  - ➢ Message 1 : suppression d’un fournisseur
-  - ➢ Message 2 : Suppression d’une domiciliation bancaire.........................................................
-- Liens Produits / Fournisseurs
-- 1 Création / Modification / Suppression d'un lien
-  - ➢ Message 1 : Informations générales liées au lien
-- Gestion des Marchés
-- 1 Création d’un marché dans la Gestion Economique et Financière
-  - ➢ Message 1 : Entête de Marché
-  - ➢ Message 2 : Lignes de Marché transmises
-- EPICURE (web) 2 Création d’un marché dans la Gestion Economique et Financière avec la nouvelle interface
-  - ➢ Message 1 : Entête de Marché
-  - ➢ Message 2 : Lignes de Marché transmises
-- 3 Transmission des consommations des produits
-  - ➢ Message 1 : Consommations par produit
-- 4 Création d’un marché
-  - ➢ Message 1 : Entête de Marché
-  - ➢ Message 2 : Lignes de Marché
-  - ➢ Message 3 : Fournisseurs par marché
-- 5 Modification de marché
-- 6 Suppression de marché
-  - ➢ Message 1 : Arrêt d’un marché
-  - ➢ Message 2 : Arrêt d’une ligne de marché
-- Demandes d’approvisionnements externes :
-- 1 Création d’une demande...................................................................................................
-  - ➢ Message 1 : Entête de demande d’approvisionnement
-  - ➢ Message 2 : Lignes de demande d’approvisionnement externe
-- Commandes
-- 1 Création d’une commande
-  - ➢ Message 1 : Entête de commande:........................................................................................
-  - ➢ Message 2 : Lignes de commande
-- 2 Modification de Commande
-- 3 Suppression de Commande
-- Livraisons provenant de l’extérieur
-- 1 Création d’une livraison externe
-  - ➢ Message 1 : Lignes de Livraison externe
-  - ➢ Message 2 : Lignes de Livraison sur produit avec gestion de lot
-- 2 Modification de lignes de Livraison
-- 3 Annulation de Livraison
-- Echantillons
-- 1 Création d’une livraison externe d’échantillon
-- Receptions
-- 1 Création d’une réception
-  - ➢ Message 1 : Lignes de Réception
-- 2 Modification de Réception
-- 3 Suppression de Réception
-- Mouvements de stocks internes
-- 1 Création d’un Mouvement de stock interne
-  - ➢ Message 1 : Mouvements de STOCK
-- 2 Envoi des listes pré établies
-  - ➢ Message 1 : Listes pré établies
-- Recettes diverses
-- 1 Création d’un Mouvement de recettes diverses
-  - ➢ Message 1 : Entête de pièce
-  - ➢ Message 2 : Lignes de pièce
+> **Note technique** : ce document est une conversion automatique de la specification Word officielle. Il sert de référence pour le skill `hpk-parser`.
 
 ## Introduction et présentation du document
 
@@ -159,7 +10,6 @@ Guillot Laëtitia P.O.O 19/10/
 
 ### ➢ Fonctionnement
 
-```
 Chaque événement concernant un utilisateur pour le serveur d’accréditation ou d’un patient
 pour les serveurs d’identité, de mouvement ou d’acte est enregistré dans la base de données
 HEXAGONE WEB, et génère un message dans la base ORACLE HEXAGONE WEB.
@@ -170,13 +20,10 @@ et qui sera en mesure de comprendre et de traiter ce message.
 Chaque application reçoit le message et renvoie un accusé de réception. Cette information
 servira en cas d’interruption de la communication pour savoir quels sont les messages qui n’ont
 jamais été reçus et le cas échéant de les renvoyer.
-```
 
 #### 1.1.1 Processus de communication
 
-```
 Il existe deux types de processus :
-```
 
 1. L’envoi de messages liés à des évènements détectés dans la base HEXAGONE WEB.
     Dans ce cas de figure, l’événement détecté active le Service Echange ou Hexaflux, pour la
@@ -193,25 +40,20 @@ Il existe deux types de processus :
     Les messages sont mis en historiques et épurés en fonction du paramétrage. De même, en
     cas de non réponse des composants externes, la communication sera automatiquement
 
-```
 interrompue après un nombre de tentatives paramétré, et le ou les administrateurs sont
 prévenus par courrier électronique.
 Il est aussi possible de planifier des arrêts de la communication pour la maintenance, ou
 de faire des arrêts immédiats.
-```
 
 2. Les demandes de création des applications externes.
 
-```
 La demande est prise en compte en mode synchrone, et l’information est retournée en
 temps réel. L’application HEXAGONE WEB génère des évènements et les gère selon le
 principe évoqué ci-dessus, mais en gérant un niveau de priorité maximal pour ce type de
 message.
-```
 
 #### 1.1.2 Format des messages
 
-```
 Rubrique Long. Format Oblig. Commentaires
 Type 2 S O PR = Produits
 FO = Fournisseurs
@@ -230,13 +72,10 @@ Suppression.
 Emetteur 15 S O HEXAGONE
 Date de l’envoi 16 Date O Date de l’envoi au format :
 YYYYMMDDHHMISSnn
-```
 
-```
 Individu 50 S O Individu au sens S3A qui a généré le
 message.
 Le reste est fonction du message.
-```
 
 #### 1.1.3 Normes à respecter lors de la constitution de messages
 
@@ -257,9 +96,7 @@ information. Par exemple, si la date de naissance n’est pas connue on aura :
 
 ## 2 Création d’un Produit
 
-```
 Uniquement prévu en envoi d’Hexagone WEB vers un autre logiciel.
-```
 
 ### ➢ Message 0 : Données générales du produit
 
@@ -287,28 +124,20 @@ YYYYMMDD
 **Code UCD** (^13) N N Code Unité commune dispensation Obligatoire si
 type Médicament
 
-```
 Code
 Médicament
-```
 
-```
 1 S N Plus utilisé depuis la version D.02 de GREF
-```
 
-```
 Niveau ATC de
 rattachement
-```
 
-```
 1 N N Obligatoire si Code ATC renseigné. Niveau
 d’arborescence :
 2 si Usage thérapeutique
 3 si sous-groupe thérapeutique
 4 si sous-groupe chimique
 5 si substance chimique
-```
 
 **Code Matériel** (^1) S N Plus utilisé depuis la version D.02 de GREF (Vide)
 **Type produit** (^3) S N Type de produit : **MED** = Médicament
@@ -373,18 +202,14 @@ Attestation** (^1) S O Plus utilisé à partir de la version D.03 de GREF
 **Code
 Fractionnable**
 
-```
 1 S O Plus utilisé à partir de la version D.03 de GREF
 (Vide)
-```
 
 **Taux de
 Majoration**
 
-```
 1 N N Obligatoire si produit rétrocédé. Valeurs :
 2 si 35%, 4 si 65% et 5 si 100%
-```
 
 **Prix Rétrocession** (^14) N N **Obligatoire** si produit rétrocédé. Le prix est TTC
 **Code édition
@@ -419,14 +244,10 @@ prescription
 **Code Hors T2A** (^1) S O **T** pour oui, **F** pour Non
 **Code LPP** (^13) S N Code transmis pour B2 à partir du 01/01/
 
-```
 Taux majoration
 Rétrocession
-```
 
-```
 5 .2 N N Taux de majoration de rétrocession
-```
 
 **Liste traceur** (^1) S N Plus envoyé à partir de la version 9 .0 2 de GREF
 (Vide)
@@ -582,16 +403,12 @@ préconisation
 1** S O Produit à utiliser dans la préconisation de
 commande. Valeur **O** pour Vrai, **N** pour Faux
 
-```
 Qté
 consommation
 forcée
-```
 
-```
 14 N N Quantité de consommation forcée pour
 préconisation. Décimalisée à 3
-```
 
 **Famille article 27** (^4) N N Plus utilisé à partir de _la version D.0_ 2 _de GEF_ (Vide)
 **Code Unité de
@@ -637,9 +454,7 @@ message)
 **Exercice
 comptable**
 
-```
 4 N O Exercice de gestion
-```
 
 **UF Magasin** (^4) N O UF magasin de stockage
 **Armoire** (^4) S N Code armoire de l’UF de stockage
@@ -685,16 +500,12 @@ Q)
 
 ## 3 Modification sur produit
 
-```
 Mêmes messages que les messages de création dès qu’une information est modifiée avec un
 mode « MODIFICATION ». Seul le message sur lequel une modification est apportée est émis.
-```
 
 ## 4 Suppression d'un produit
 
-```
 Message émis lors de la saisie d’une date de fin sur le produit.
-```
 
 **Rubrique** (^) **Long. Format Oblig. Commentaires
 Type** (^2) S O Type du message :PR = Produits
@@ -720,7 +531,6 @@ Uniquement prévu en envoi d’Hexagone WEB vers un autre logiciel.
 
 Message obligatoire en création de fournisseur.
 
-```
 Rubrique Long. Format Oblig. Commentaires
 Type 2 S O Type du message :FO : Fournisseur
 Message 2 S O M
@@ -731,27 +541,17 @@ YYYYMMDDHHMISSnn
 Individu
 (émetteur du
 message)
-```
 
-```
 50 S O Individu au sens S3A qui a généré le message.
-```
 
-```
 Code
 Fournisseur
-```
 
-```
 6 S O Numéro Identifiant Fournisseur (Unique)
-```
 
-```
 Code divers
 (O/N)
-```
 
-```
 1 S O Code permettant de regrouper des fournisseurs
 occasionnels sous un même code divers. Dans ce
 cas, toutes les informations utiles dans la pièce
@@ -762,15 +562,13 @@ Raison sociale 38 S O Raison sociale du fournisseur en Majuscules
 Adresse 1 38 S N Complément destinataire
 Adresse 2 38 S N N° Voie et voie
 Code postal 5 N O Code postal
-```
 
 **Ville 38** S O Obligatoire majuscule
 
 **Bureau
 distributeur**
 
-##### 27 S O
-
+27 S O
 **No téléphone 16** S N No téléphone du fournisseur
 
 **No de Fax 16** S N No de Fax
@@ -780,10 +578,8 @@ distributeur**
 **Compte tiers
 exploit.**
 
-```
 12 N O No de compte de tiers pour les factures sur la
 section d’exploitation.
-```
 
 **No de SIRET 14** S N No de SIRET du fournisseur
 
@@ -791,20 +587,16 @@ section d’exploitation.
 tiers
 investissement**
 
-```
 12 N O No de compte de tiers pour les factures sur la
 section d’investissement
-```
 
 **Code APE 4** S N Code APE du fournisseur
 
 **Délai de
 paiement**
 
-```
 3 N N Nombre de jours pour le délai de paiement des
 factures de ce fournisseur
-```
 
 **Date de début 8** Date O Date de début d’utilisation de ce fournisseur.
 Format YYYYMMDD
@@ -816,28 +608,22 @@ YYYYMMDD
 regroupement
 facture**
 
-```
 1 S O Code permettant d’indiquer si on peut regrouper
 plusieurs factures sur les mandats pour ce
 fournisseur.. Valeurs T pour Vrai, F pour faux
-```
 
 **Code
 concurrentiel**
 
-```
 1 S O Code fournisseur concurrentiel ou pas. T pour
 Vrai, F pour faux
-```
 
 **Adresse EMAIL 255** S N Adresse EMAIL de la Maison Mère
 
 **Type de
 fournisseur**
 
-```
 10 S N Type de fournisseur
-```
 
 **Adresse 3 38** S N Complément d’adresse
 
@@ -847,23 +633,16 @@ fournisseur**
 
 **Résident 1** S O Résident en france ( **F** / **T** )
 
-```
 Complément
 du nom
-```
 
-```
 38 S N Complément du nom
-```
 
-```
 Prénom 38 S N Prénom
 Civilité 10 S N Civilite : MR, MME, MELLE
 Nature
 identifiant
-```
 
-```
 2 S N Nature de l'identifiant du tiers
 exemple : 00 Aucun, 01 SIRET, 02 SIREN, 03
 FINESS, 04 NIR, 05 TVAIntraCo, 06 Hors UE, 07
@@ -873,28 +652,19 @@ des personnes physiques), 12 NFP (Numéro des
 finances publiques)
 Identifiant du
 tiers
-```
 
-```
 18 S N Identifiant du tiers
 N° SIREN, SIRET, FINESS ou autre ....
 Catégorie du
 tiers
-```
 
-```
 2 S O Catégorie du tiers
-```
 
-```
 Nature
 juridique du
 tiers
-```
 
-```
 2 S O Nature juridique du tiers
-```
 
 **Franco de Port** (^13) N N Décimalisé à 2, montant franco de port
 
@@ -911,33 +681,21 @@ Type** (^2) S O Type du message :FO : Fournisseur
 **Date de l’envoi 16** Date^ O Date de l’envoi au format :
 YYYYMMDDHHMISSnn
 
-```
 Individu
 (émetteur du
 message)
-```
 
-```
 50 S O Individu au sens S3A qui a généré le message.
-```
 
-```
 Code
 Fournisseur
-```
 
-```
 6 S O Numéro Identifiant Fournisseur (Unique)
-```
 
-```
 No de
 domiciliation
-```
 
-```
 2 N O Numéro de domiciliation bancaire de 01 à 99
-```
 
 **Clé RIB** (^2) N O Clé RIB associée à la domiciliation bancaire 2
 Chiffres
@@ -1005,26 +763,18 @@ d’adresse
 **Code pays 3** S O Code pays
 **Résident 1** S O Résident en france ( **F** / **T** )
 
-```
 Complément du
 nom
-```
 
-```
 38 S N Complément du nom
-```
 
-```
 Prénom 38 S N Prénom
 Civilité 10 S N Civilite : MR, MME, MELLE
-```
 
 ## 2 Modification Fournisseurs
 
-```
 Mêmes messages que les messages de création dès qu’une information est modifiée avec un
 mode « MODIFICATION »
-```
 
 ## 3 Suppression fournisseur
 
@@ -1152,9 +902,7 @@ YYYYMMDDHHMISSnn
 (émetteur du
 message)**
 
-```
 50 S O Individu au sens S3A qui a généré le message.
-```
 
 **Code Fournisseur** (^6) S O Numéro Identifiant Fournisseur (Unique)
 **Code produit** (^8) S O Code identifiant produit
@@ -1249,10 +997,8 @@ C : Négocié sans concurrence
 T : Travaux
 A : Article 30
 
-```
 U : Besoin unique
 N : Autres
-```
 
 **Nature** (^1) S O Obligatoire si type = ‘T’(Travaux). Valeurs
 autorisées :
@@ -1296,50 +1042,32 @@ Marché
 11** N O Monétaire décimalisé à 2 (par n° de marché)
 Si Marché en Mini/Maxi, Montant maxi HT
 
-```
 par n° de marché, par fournisseur
 Montant TTC du
 Marché
-```
 
-```
 11 N O Monétaire décimalisé à 2 (par n° de marché)
 Si Marché en Mini/Maxi, Montant maxi TTC
 par n° de marché, par fournisseur
 Date de début de
 période
-```
 
-```
 8 Date O Date de début de période. Format YYYYMMDD
-```
 
-```
 Date de fin de
 période
-```
 
-```
 8 Date O Date de fin de période. Format YYYYMMDD
-```
 
-```
 Durée de la
 période
-```
 
-```
 2 N O Nombre de mois de la période
-```
 
-```
 Type de
 procédure
-```
 
-```
 2 S O Type de procédure à saisir avant l’export
-```
 
 Remarque : Si le marché porte sur plusieurs fournisseurs, on aura autant d’enregistrements
 
@@ -1364,9 +1092,7 @@ YYYYMMDDHHMISSnn
 (émetteur du
 message)**
 
-```
 50 S O Individu au sens S3A qui a généré le message.
-```
 
 **No de marché** (^8) S O No de marché attribué par le logiciel émetteur
 **ATTENTION dans la Gestion Economique et
@@ -1496,24 +1222,16 @@ marché sera rejeté.
 
 ### ➢ Message 1 : Entête de Marché
 
-```
 Rubrique Long. Forma
 t
-```
 
-```
 Obli
 g.
-```
 
-```
 Commentaires
-```
 
-```
 Type 2 S O Type du message :MT : Marchés Transmis
 Message 2 S O M1
-```
 
 **Mode 1** S O C
 
@@ -1521,33 +1239,25 @@ Message 2 S O M1
 
 **Date de l’envoi 16** Date^ O Date de l’envoi au format :
 
-```
 YYYYMMDDHHMISSnn
-```
 
 **Individu
 (émetteur du
 message)**
 
-```
 50 S O Individu au sens S3A qui a généré le message.
-```
 
 **No de marché 8** S O No de marché attribué par le logiciel émetteur.
 
-```
 ATTENTION dans la Gestion Economique et
 Financière : No sur 6 en numérique avec les 2
 premiers correspondants à l’exercice (exemple sur
 2003, no 030001)
-```
 
 **Code
 fournisseur**
 
-```
 6 S O Doit exister dans Hexagone WEB
-```
 
 **Raison sociale 38** S O Doit exister dans Hexagone WEB
 
@@ -1558,46 +1268,35 @@ fournisseur**
 **No du compte
 bancaire**
 
-##### 11 S O
-
+11 S O
 **Clé RIB 2** N O
 
 **Délai de
 Paiement**
 
-```
 3 N N Nombre de jours. Compris entre 001 et 999
-```
 
 **Date de
 Consultation**
 
-```
 8 Date O Date de lancement de la consultation du marché.
 Format YYYYMMDD
-```
 
 **Date de
 Notification**
 
-```
 8 Date O Date de notification au titulaire. Format
 YYYYMMDD
-```
 
 **Date début de
 marché**
 
-```
 8 Date O Format YYYYMMDD
-```
 
 **Date de fin
 marché**
 
-```
 8 Date O Format YYYYMMDD
-```
 
 **Marché alloti 1** S O T : pour marché alloti, F sinon
 
@@ -1605,74 +1304,56 @@ marché**
 
 **(retenus)**
 
-```
 4 N N Si marché alloti, donne le nombre de lots associés
-```
 
 **Marché à bon
 de commande**
 
-```
 1 S O Valeurs F pour Non, T pour Oui
-```
 
 **Reconductible 1** S O Valeurs F pour Non, T pour Oui
 
 **Nombre de
 reconductions**
 
-```
 3 N O Obligatoire sir code « Reconductible » est à T.
 Compris entre 001 et 999.
-```
 
 **Gestion
 Interne**
 
-```
 1 S O Valeur F pour Non, T pour Oui.
-```
 
 **Pourcentage
 maxi de
 blocage**
 
-```
 5 N N Décimalisé à 2.
-```
 
 **Type de
 marché**
 
-```
 1 S N Positionnement non utilisé dans cette version
-```
 
 **Nature 1** S N Positionnement non utilisé dans cette version
 
 **Code CMP
 dominant**
 
-```
 10 S F Obligatoire si type marché = ‘M’.
-```
 
 **Groupement
 d’achat**
 
-```
 1 S O T si marché dans le cadre d’un groupement
 d’achat, F si marché propre à l’établissement.
-```
 
 **Taux des
 Intérêts
 moratoires**
 
-```
 5 N F Numérique décimalisé à 2. Taux spécifique pour le
 marché
-```
 
 **Code IBAN 34** S N Code IBAN ( _International Bank Account Number_ .)
 
@@ -1681,111 +1362,85 @@ marché
 **Mini/Maxi
 (O/N)**
 
-```
 1 S O Marché en Mini/Maxi
 F pour non, T pour oui
-```
 
 **Gpt Achat
 (O/N)**
 
-```
 1 S O Marché en groupement d’achat
 F pour non, T pour oui
-```
 
 **Accord cadre
 (O/N)**
 
-```
 1 S O Marché accord cadre
 F pour non, T pour oui
-```
 
 **Marché
 subséquent
 (O/N)**
 
-```
 1 S N Marché subséquent
 F pour non, T pour oui (non utilisé actuellement)
-```
 
 **Montant
 minimum de
 commande**
 
-```
 9 N N Montant minimum de commande
-```
 
 **Franco de port 9** N N Monétaire décimalisé à 2 (montant HT)
 
 **Montant HT du
 Marché**
 
-```
 11 N O Monétaire décimalisé à 2 (par n° de marché)
 Si Marché en Mini/Maxi, Montant maxi HT
 par n° de marché, par fournisseur
-```
 
 **Montant TTC
 du Marché**
 
-```
 11 N O Monétaire décimalisé à 2 (par n° de marché)
 Si Marché en Mini/Maxi, Montant maxi TTC
 par n° de marché, par fournisseur
-```
 
 **Date de début
 de période**
 
-```
 8 Date N Date de début de période. Format YYYYMMDD
 (non utilisé actuellement)
-```
 
 **Date de fin de
 période**
 
-```
 8 Date N Date de fin de période. Format YYYYMMDD (non
 utilisé actuellement)
-```
 
 **Durée de la
 période**
 
-```
 2 N O Nombre de mois de la période
-```
 
 **Type de
 procédure**
 
-```
 2 S O Type de procédure à saisir avant l’export
-```
 
 **Caractéristique
 s du marché**
 
-```
 1 S O Caractéristiques M = mixte, C = négocié sans
 concurrence, A = article 30, N = aucune
 caractéristique (normal)
 Obligatoirement à N si Nature = T
-```
 
 **Type de
 marché**
 
-```
 1 S O Types T = travaux, F = fourniture, S = service
 Obligatoirement à T si nature = T
-```
 
 **Nature 1** S O Nature du marché T = travaux, B = à bon de
 commande, A = autre
@@ -1836,10 +1491,8 @@ ordonnateur
 **Quantité minimum
 retenue**
 
-```
 14 N N Quantité minimum pour les marchés à bon de
 commande Décimalisée à 3
-```
 
 **Quantité moyenne** (^14) N N Quantité moyenne. Décimalisée à 3. Non utilisée
 dans la Gestion Economique et Financière
@@ -1884,14 +1537,12 @@ Rupture sur N° ligne de marché + N°lot + N°sous
 lot :
 Montant proposé =
 
-```
 Cumul de tous les produits au mode de calcul
 « Somme »
 +
 Moyenne de tous les produits au mode de calcul
 « Moyenne »
 (non utilisé actuellement)
-```
 
 **Code fournisseur** (^6) S O Doit exister dans Hexagone WEB (10 car maxi
 dans Epicure+)
@@ -1930,13 +1581,11 @@ par l'établissement.
 
 ## 3 Transmission des consommations des produits
 
-```
 Ces enregistrements sont uniquement envoyés par la Gestion Economique et Financière pour
 un logiciel extérieur.
 Ces messages sont notamment destinés à alimenter les logiciels de gestion des marchés avec
 les consommations des produits stockés constatées dans Hexagone WEB, pour un magasin
 donné, sur une période donnée.
-```
 
 ### ➢ Message 1 : Consommations par produit
 
@@ -1969,11 +1618,9 @@ d’historique
 fournisseur du
 marché**
 
-```
 6 S N Si marché en cours sur ce produit lors de
 l’extraction, le code fournisseur est transmis. C’est
 le code Hexagone
-```
 
 **Raison sociale** (^38) S N Raison sociale du fournisseur du marché
 **PU HT du
@@ -1999,10 +1646,8 @@ Décimalisée à 3.
 
 ## 4 Création d’un marché
 
-```
 Les marchés peuvent être uniquement envoyés depuis la Gestion Economique et Financière
 vers un autre destinataire.
-```
 
 ### ➢ Message 1 : Entête de Marché
 
@@ -2044,9 +1689,7 @@ marché
 **Date de fin
 marché**
 
-```
 8 Date O Format YYYYMMDD
-```
 
 **Marché alloti** (^1) S O **T** : pour marché alloti, **F** sinon
 **Nbre de lots** (^4) N F Si marché alloti, donne le nombre de lots associés
@@ -2088,10 +1731,8 @@ d’achat, **F** si marché propre à l’établissement.
 Intérêts
 moratoires**
 
-```
 5 N F Numérique décimalisé à 2. Taux spécifique pour le
 marché
-```
 
 **Observations** (^80) S F Observations
 
@@ -2138,20 +1779,14 @@ des marchés publics.
 minimum de
 commande**
 
-##### 14 N N
+14 N N
 
-```
 Quantité minimum à commander. Décimalisée à 3
-```
 
-```
 Code Unité de
 conditionnement
-```
 
-```
 5 S N Code unité de conditionnement du fournisseur, existe dans la table HXUNDIST
-```
 
 **Nombre d’unités** (^14) N N Nombre d’unités de gestion dans fournisseur. Décimalisé à 3 l’unité de conditionnement du
 **Délai de livraison** (^3) N N Nombre de jours pour délai de livraison.^
@@ -2161,33 +1796,23 @@ principal
 **No de point de
 commande**
 
-##### 2 N O
+2 N O
 
-```
 Par défaut 01. Point de commande habituel pour le produit.
-```
 
-```
 Référence du
 produit chez le
 fournisseur
-```
 
-##### 1024 S N
+1024 S N
 
-```
 Texte permettant l’identification du produit chez le fournisseur,
 il sera repris sur les bons de commande
-```
 
-```
 Référence
 fournisseur
-```
 
-```
 30 S N Références exactes du produit chez le fournisseur sans annotation personnelle.
-```
 
 **Code fabricant** (^13) S N Code fabricant lié au LPPR (liste des produits et prestations remboursables, ancien nom LPP).
 
@@ -2195,12 +1820,9 @@ fournisseur
 
 Uniquement si marché multi fournisseurs et/ou marché alloti
 
-```
 Rubrique Long. Format Oblig. Commentaires
 Type 2 S O Type du message :MA : Marchés
-```
 
-```
 Message 2 S O M3
 Mode 1 S O C
 Emetteur 15 S O HEXAGONE
@@ -2209,55 +1831,38 @@ YYYYMMDDHHMISSnn
 Individu
 (émetteur du
 message)
-```
 
-```
 50 S O Individu au sens S3A qui a généré le message.
-```
 
-```
 No de marché 6 N O No de marché attribué par l’établissement
 No de lot 4 N O No de lot associé au fournisseur
 Code
 fournisseur
-```
 
-```
 6 S O Code fournisseur Hexagone WEB associé
-```
 
-```
 No de
 domiciliation
 bancaire
-```
 
-```
 2 N O No de domiciliation bancaire du fournisseur, pour
 gestion des règlements.
-```
 
-```
 Date début 8 Date O Format YYYYMMDD
 Date de fin 8 Date O Format YYYYMMDD
 Libellé du lot 150 S N Libellé du lot
-```
 
 ## 5 Modification de marché
 
-```
 Mêmes messages que les messages de création dès qu’une information est modifiée avec un
 mode « MODIFICATION »
-```
 
 ## 6 Suppression de marché
 
 ### ➢ Message 1 : Arrêt d’un marché
 
-```
 Rubrique Long. Format Oblig. Commentaires
 Type 2 S O Type du message :MA : Marchés
-```
 
 **Message 2** S O M1
 
@@ -2274,9 +1879,7 @@ YYYYMMDDHHMISSnn
 (émetteur du
 message)**
 
-```
 50 S O Individu au sens S3A qui a généré le message.
-```
 
 **No de marché 6** N O No de marché attribué par l’établissement
 
@@ -2297,35 +1900,27 @@ MA : Marchés
 
 **Date de l’envoi 16** Date^ O Date de l’envoi au format :
 
-```
 YYYYMMDDHHMISSnn
-```
 
 **Individu
 (émetteur du
 message)**
 
-```
 50 S O Individu au sens S3A qui a généré le message.
-```
 
 **No de marché 6** N O No de marché attribué par l’établissement
 
 **No ligne
 marché**
 
-```
 3 N O No de ligne clôturée.
-```
 
 **Code produit 8** S N Obligatoirement renseigné si ligne sur produit
 
 **Compte
 ordonnateur**
 
-```
 13 S N Obligatoirement renseigné si ligne sur compte
-```
 
 **Code CMP 10** S O Obligatoire code nomenclature du nouveau code
 des marchés publics.
@@ -2413,24 +2008,18 @@ d’approvisionnements
 
 **Date de l’envoi 16** Date^ O Date de l’envoi au format :
 
-```
 YYYYMMDDHHMISSnn
-```
 
 **Individu
 (émetteur du
 message)**
 
-```
 50 S O Individu au sens S3A qui a généré le message.
-```
 
 **Date de
 demande**
 
-```
 8 Date O Format YYYYMMDD
-```
 
 **No de demande** (^10) S O
 **No de ligne** (^3) N O No de ligne de demande : 001 à 999 maximum.
@@ -2532,16 +2121,12 @@ commande.
 **Objet
 commande**
 
-```
 40 S N Objet de commande
-```
 
 **Date de
 commande**
 
-```
 8 Date O Format YYYYMMDD
-```
 
 **Date de livraison** (^8) Date N Date de livraison. Format YYYYMMDD
 **Montant TTC de
@@ -2673,14 +2258,10 @@ Imprévisible
 1** S O Plus envoyé à partir de la version 9.02 de GREF
 (Vide)
 
-```
 Libellé long
 produit
-```
 
-```
 150 S N Renseigné si code produit présent
-```
 
 **Type produit** (^3) D N Type de produit : **MED** = Médicament
 **MAT** = Matériel Médical
@@ -2784,14 +2365,10 @@ HEXAGONE WEB
 Permet de faire le lien avec le numéro de ligne de
 commande associée la ligne de livraison
 
-```
 No de Bordereau
 de livraison
-```
 
-```
 10 S N No du BL du fournisseur
-```
 
 **Code fournisseur** (^6) S O Fournisseur HEXAGONE WEB effectuant la
 livraison
@@ -2881,14 +2458,10 @@ produit n'a pas de lot
 **No de série** (^30) S F N° de série - Obligatoire si le produit
 HEXAGONE WEB le gère.
 
-```
 Date de
 péremption
-```
 
-```
 8 Date O Date de péremption du lot reçu
-```
 
 **Quantité reçue** (^14) N O Le total des lignes par produit doit être égal
 à la quantité totale reçue. Décimalisée à 3.
@@ -2940,43 +2513,33 @@ intégration. Fonctionne uniquement avec HEXAFLUX.
 **Date de
 l’envoi**
 
-```
 16 Date O Date de l’envoie au format :
 YYYYMMDDHHMISSnn
-```
 
 **Individu
 (émetteur
 du message)**
 
-```
 50 S O Individu au sens S3A qui a généré le message.
-```
 
 **Date
 D’annulatio
 n**
 
-```
 8 Date O Format YYYYMMDD
-```
 
 **No de
 réception de
 l’émetteur**
 
-```
 10 S O No de réception de l’émetteur
-```
 
 **No de
 commande
 de
 l’émetteur**
 
-```
 10 S O No de commande de l’émetteur
-```
 
 ## Echantillons
 
@@ -2987,7 +2550,6 @@ de l’émetteur doit être renseigné et il sera stocké **comme un mouvement d
 d’entrée** de la Gestion Economique et Financière qui sera généré si tous les contrôles sont
 corrects. Fonctionne uniquement avec HEXAFLUX.
 
-```
 Rubrique Long. Format Oblig. Commentaires
 Type 2 S O Type du message : EC : Echantillons
 Message 2 S O M1
@@ -2998,53 +2560,35 @@ YYYYMMDDHHMISSnn
 Individu
 (émetteur du
 message)
-```
 
-##### 50 S O PHARMA
-
-```
+50 S O PHARMA
 Date de
 livraison des
 échantillons
-```
 
-```
 8 Date O Format YYYYMMDD
-```
 
-```
 No de
 réception de
 l’émetteur
-```
 
-```
 10 S O No de réception des échantillons de l’émetteur
-```
 
-```
 Code
 fournisseur
-```
 
-```
 6 S O Fournisseur HEXAGONE WEB effectuant la
 livraison
 UF magasin de
 réception
-```
 
-```
 4 N O Doit exister dans HEXAGONE WEB et être associée
 comme UF magasin principale sur les produits
 Code produit 8 S O Obligatoire
 Signe du
 Mouvement
-```
 
-```
 1 S O P pour positif – N pour Négatif
-```
 
 **Quantité livrée 14** N O Décimalisée à 3.^
 Quantité > 0 (Positive) , doit être exprimée dans
@@ -3056,24 +2600,18 @@ marché
 **No Lot de
 Marché**
 
-```
 2 N N Uniquement si marché alloti
-```
 
 **No de Lot du
 Produit**
 
-```
 30 S N No de lot de l’échantillon
-```
 
 **Date de
 Péremption du
 lot**
 
-```
 8 Date N Obligatoire si No de lot renseigné
-```
 
 **Commentaire 40** S N Permet d’identifier le mouvement
 
@@ -3119,18 +2657,14 @@ Réception
 CMP :
 **F** : Réception Normale
 
-```
 T : Réception Travaux
-```
 
 **No de
 commande
 HEXAGONE WEB**
 
-```
 8 N O No de commande dans la Gestion Economique et
 Financière associé à la réception
-```
 
 **No de ligne cde** (^3) N O No de ligne de commande : 001 à 999 maximum.
 **No de Bordereau
@@ -3220,7 +2754,6 @@ les contrôles sont corrects.
 **_Ces messages concernent uniquement les produits gérés en stock et non gérés en
 entrées/sorties simultanées :_**
 
-```
 A - Les sorties de stock classiques des magasins et / ou armoires de service :
 Consommations de produits par les services, et gestion des retours de service. Dans ce
 cas, 2 possibilités sont offertes :
@@ -3236,27 +2769,22 @@ l’arrêté de balance définitive : L’intégration de ces mouvements génèr
 de sorties normaux..
 (Message de type SO, code Message S1 avec champ Valeur de la sortie non
 renseignée)
-```
 
 **B - Les inventaires de stock par magasin et / ou armoire de service** :
 
-```
 Ces mouvements permettront de générer un état d’inventaire qui sera rapproché du
 stock géré dans la Gestion Economique et Financière dans les procédures de gestion des
 inventaires des stocks. Ces messages sont purement quantitatifs.
 (Message de type SO, code Message I1 avec champ Valeur de la sortie non
 renseignée)
-```
 
 **C - Les transferts entre magasins de l ‘établissement**
 
-```
 Ces mouvements permettront de gérer dans la Gestion Economique et Financière les
 mouvements entre magasins et / ou armoires de service à l’intérieur de l’établissement.
 Ces mouvements ne rentrent pas dans la comptabilisation des consommations.
 (Message de type SO, code Message T1 avec champ Valeur de la sortie non
 renseignée)
-```
 
 ### ➢ Message 1 : Mouvements de STOCK
 
@@ -3288,16 +2816,13 @@ destinatrice
 4** N O Pour les messages S1 : UF destinatrice de la sortie
 ou faisant le retour
 
-```
 Pour les messages I1 : Mettre 0000
 Pour les messages T1 : UF magasin réceptionnant
 le produit transféré
-```
 
 **Code Armoire de
 l’UF destinatrice**
 
-```
 4 S N Uniquement renseigné si gestion des armoires
 dans la Gestion Economique et Financière.
 Pour les messages S1 : Code armoire associé à UF
@@ -3305,7 +2830,6 @@ destinatrice de la sortie ou faisant le retour
 Pour les messages I1 : Mettre 0000
 Pour les messages T1 : Code armoire de l’ UF
 magasin réceptionnant le produit transféré
-```
 
 **Code produit** (^8) S O Identifiant du produit dans la Gestion Economique
 et Financière : peut-être soit le code produit soit le
@@ -3331,12 +2855,10 @@ code IUD-IP (Identifiant Production : numéro de
 série, numéro de lot, date de fabrication, date
 d'expiration).
 
-```
 Il y a 4 types selon le standard choisi pour le code
 IUD-ID : GTIN (standard GS1), UPN (standard
 HIBC), PPN (standard IFA) et PPIC (standard ISBT
 128).
-```
 
 **IUDID** (^25) S N Le code IUD-ID (Identifiant Dispositif : code
 fabricant, modèle, conditionnement) est le
@@ -3369,15 +2891,11 @@ message)
 0000)
 **UF cliente** (^4) N O UF cliente associée à la liste
 
-```
 Code Armoire
 Cliente
-```
 
-```
 4 S N Code de l’armoire associée à l’UF cliente. Si pas de
 gestion des armoires valeur 0000
-```
 
 **Code liste** (^8) S O Nom de la liste
 **Code produit** (^8) S O Code produit
@@ -3417,24 +2935,18 @@ RD : Pièce de recettes diverses
 
 **Date de l’envoi 16** Date^ O Date de l’envoi au format :
 
-```
 YYYYMMDDHHMISSnn
-```
 
 **Individu
 (émetteur du
 message)**
 
-```
 50 S O Individu au sens S3A qui a généré le message.
-```
 
 **No de pièce de
 l’expéditeur**
 
-```
 10 S O No d’identifiant unique de la pièce
-```
 
 **Exercice** (^4) N O Exercice comptable d’imputation de la pièce
 **Code débiteur** (^6) S O Code débiteur destinataire du titre à émettre.

--- a/docs/tdd.md
+++ b/docs/tdd.md
@@ -2,6 +2,13 @@
 
 Le **TDD (Test-Driven Development)** est une méthode de développement piloté par les tests. Ce skill guide l'agent IA pour appliquer le cycle red-green-refactor de manière rigoureuse.
 
+## Pourquoi ce skill
+
+- **Moins de bugs en production** — Les tests écrits avant le code détectent les régressions immédiatement
+- **Confiance lors des refactorings** — Modifier du code existant sans risque grâce à un filet de tests solide
+- **Spécifications vivantes** — Les tests documentent le comportement attendu mieux qu'un cahier des charges
+- **Feedback rapide** — Chaque cycle dure quelques minutes, pas des jours
+
 ## Qu'est-ce que le TDD ?
 
 - Vous écrivez les tests **avant** le code de production

--- a/docs/web-design-guidelines.md
+++ b/docs/web-design-guidelines.md
@@ -2,6 +2,13 @@
 
 Inspection visuelle et revue de code pour la conformité aux Web Interface Guidelines. Supporte l'analyse statique et l'inspection via navigateur.
 
+## Pourquoi ce skill
+
+- **Accessibilité obligatoire** — La conformité WCAG est un enjeu légal et un impératif d'inclusion
+- **Cohérence utilisateur** — Une UI homogène réduit la courbe d'apprentissage et les erreurs de saisie
+- **Qualité perçue** — Les détails visuels (alignement, espacement, responsive) construisent la confiance utilisateur
+- **Détection automatique** — Repère en quelques secondes des problèmes qu'un audit manuel prendrait des heures à identifier
+
 ## Quand utiliser ce skill
 
 Utilisez ce skill pour :

--- a/skills/code-review/SKILL.md
+++ b/skills/code-review/SKILL.md
@@ -1,13 +1,13 @@
 ---
-name: gitlab-code-review
-description: "Effectue des revues de code complètes des merge requests GitLab, analysant la qualité du code, la sécurité, les performances et les bonnes pratiques. À utiliser quand l'utilisateur dit « review » ou « code review » ou demande de revoir des merge requests ou d'analyser les changements d'une branche avant fusion."
-version: 1.1.0
+name: code-review
+description: "Effectue des revues de code complètes des merge requests GitLab, analysant la qualité du code, la sécurité, les performances et les bonnes pratiques. À utiliser quand l'utilisateur dit « code review » ou demande de revoir des merge requests ou d'analyser les changements d'une branche avant fusion."
+version: 2.0.0
 license: MIT
 metadata:
   author: Foundation Skills
 ---
 
-# GitLab Code Review
+# Code Review
 
 Perform comprehensive code reviews of GitLab merge requests, providing actionable feedback on code quality, security, performance, and best practices.
 

--- a/skills/issue-review/SKILL.md
+++ b/skills/issue-review/SKILL.md
@@ -1,0 +1,494 @@
+---
+name: issue-review
+description: "Lance une revue d'issue automatique avec des personas experts sélectionnés automatiquement, analyse la faisabilité, la complétude, les risques et l'architecture, puis publie un rapport structuré directement sur l'issue — le tout sans intervention de l'utilisateur."
+version: 1.0.0
+license: MIT
+metadata:
+  author: Foundation Skills
+---
+
+# Issue Review
+
+Run a fully autonomous multi-angle review of a GitLab or GitHub issue using expert personas. The skill fetches issue context, explores the relevant codebase, runs a 3-round persona meeting (opening statements, debate, weighted convergence), and posts a structured review comment directly on the issue — all without asking the user for confirmation.
+
+## When to Use This Skill
+
+Activate when the user:
+- Demande une « revue d'issue » ou « issue review » sur une issue
+- Dit « issue-review #42 » ou « issue-review <URL> »
+- Veut analyser une issue sous plusieurs angles avant implémentation
+- Veut un avis structuré sur la faisabilité, la complétude et les risques d'une issue
+
+## Core Principles
+
+### 1. Full Autonomy
+- The entire pipeline runs without asking any user questions (except for closed issues — see Edge Cases)
+- Persona selection is automatic based on issue content analysis
+- The review comment is posted directly on the issue
+
+### 2. Multi-Angle Analysis
+- Personas review feasibility, completeness, risks, and architecture
+- 3 full rounds ensure genuine debate and richer analysis
+- Each persona brings a genuinely different viewpoint
+
+### 3. Contextual Depth
+- The skill reads the full issue: description, all comments, labels
+- If a branch is linked, the branch diff is analyzed
+- The existing codebase is explored automatically to give personas informed context
+
+### 4. Analytical Only
+- This skill does NOT implement anything
+- It produces a review with actionable next steps
+- The team reads the analysis and decides what to do
+
+## Workflow
+
+### Step 1: Identify and Fetch the Issue
+
+1. **Parse the user's input** to extract the issue reference:
+   - Issue number: `#42`
+   - Full URL: `https://gitlab.example.com/group/project/-/issues/42` or `https://github.com/owner/repo/issues/42`
+   - If no valid issue reference is found, ask the user to provide one
+
+2. **Detect the remote repository type:**
+   - Run `git remote -v` to determine if the remote is GitLab or GitHub
+   - Store this for Step 7 (posting the comment)
+
+3. **Fetch the issue details:**
+   - **GitLab:** `glab issue view <iid>` — title, description, labels, state
+   - **GitHub:** `gh issue view <number>` — title, body, labels, state
+
+4. **Fetch all issue comments:**
+   - **GitLab:** `glab issue note list <iid>` or `glab api /projects/:id/issues/:iid/notes`
+   - **GitHub:** `gh issue view <number> --comments`
+
+5. **Check issue state:**
+   - If the issue is **closed**, warn the user and ask for confirmation before proceeding (see Edge Cases)
+   - If the issue is **open**, proceed normally
+
+6. **Check for minimal content** (see Edge Cases):
+   - If the issue has no description or only a one-line title with no meaningful content, skip the meeting and post a short comment listing what's missing
+
+### Step 2: Gather Full Context
+
+#### Issue Context
+- Issue title, description, and all comments (collected in Step 1)
+- Labels and milestones (for domain detection)
+
+#### Linked Branch Context
+1. **Check for linked branches:**
+   - **GitLab:** Check the issue for related merge requests via `glab api /projects/:id/issues/:iid/related_merge_requests` or look for branch references in the issue/comments
+   - **GitHub:** Check for linked pull requests via `gh pr list --search "<issue reference>"`
+2. **If a branch exists:**
+   - Fetch the diff: `git diff main...<branch>` (or the appropriate base branch)
+   - Include the diff summary and key file changes in the persona context
+
+#### Codebase Context
+1. **Analyze the issue content** to identify which parts of the codebase are relevant:
+   - File paths, module names, function names, or components mentioned in the issue or comments
+   - Domain keywords that map to specific directories or files
+2. **Explore the codebase** — read relevant files to understand the current state:
+   - Use Glob and Grep to find related files
+   - Read the most relevant files (prioritize files explicitly mentioned, then files in related modules)
+   - Understand existing patterns, architecture, and conventions
+3. **Build a context summary** for the personas including:
+   - Issue content (description + comments)
+   - Linked branch diff (if any)
+   - Relevant codebase snippets and architecture overview
+
+### Step 3: Auto-Select Personas
+
+Automatically select 3-4 personas based on the issue content, labels, and domain. Use these heuristics:
+
+| Le sujet concerne... | Personas auto-sélectionnés |
+|---------------------|---------------------|
+| Backend / API / base de données | SOLID Alex (Backend), Whiteboard Damien (Architecte), EXPLAIN PLAN Isabelle (DBA Oracle) |
+| Frontend / UI / UX | Pixel-Perfect Hugo (Frontend), Figma Fiona (UX/UI), Sprint Zero Sarah (PO), Whiteboard Damien (Architecte) |
+| Sécurité / auth / contrôle d'accès | Paranoid Shug (Sécurité), RGPD Raphaël (DPO), SOLID Alex (Backend), Whiteboard Damien (Architecte) |
+| Infrastructure / déploiement / CI-CD | Pipeline Mo (DevOps), SOLID Alex (Backend), Whiteboard Damien (Architecte) |
+| Données / migration / ETL | Schema JB (Data), EXPLAIN PLAN Isabelle (DBA Oracle), Whiteboard Damien (Architecte) |
+| Interopérabilité / HL7 / FHIR / HPK | RFC Santiago (PO Interop), HL7 Victor (Dev Interop), SOLID Alex (Backend) |
+| Legacy / Uniface / modernisation | Legacy Larry (Uniface), Whiteboard Damien (Architecte), SOLID Alex (Backend) |
+| Tests / qualité / régression | Edge-Case Nico (QA), SOLID Alex (Backend), Pipeline Mo (DevOps) |
+| Produit / fonctionnalité / décision UX | Sprint Zero Sarah (PO), Pixel-Perfect Hugo (Frontend), Figma Fiona (UX/UI), Whiteboard Damien (Architecte) |
+| Santé / workflows cliniques | Dr. Workflow Wendy (Santé), Sprint Zero Sarah (PO), RGPD Raphaël (DPO) |
+| RGPD / données personnelles / conformité | RGPD Raphaël (DPO), Paranoid Shug (Sécurité), Whiteboard Damien (Architecte) |
+| BI / tableaux de bord / reporting / finance / comptabilité | Dashboard Estelle (BI Finance), Pixel-Perfect Hugo (Frontend), EXPLAIN PLAN Isabelle (DBA Oracle), Whiteboard Damien (Architecte) |
+| Full-stack / sujet transverse | Whiteboard Damien (Architecte), SOLID Alex (Backend), Sprint Zero Sarah (PO), Edge-Case Nico (QA) |
+
+Si le sujet couvre plusieurs domaines, choisir les 3-4 personas les plus pertinents.
+
+**Pool complet des personas avec rôles, perspectives et biais :** see `reference/personas.md`.
+
+**Announce the selected personas and their roles before starting the meeting.**
+
+### Step 4: Run the Review Meeting
+
+The meeting uses sub-agents to run each persona independently and in parallel. The review meeting runs 3 full rounds for depth.
+
+**IMPORTANT: Use the Agent tool to launch each persona as a separate sub-agent.**
+
+#### Round 1: Opening Statements (Parallel Sub-Agents)
+
+Launch one sub-agent per persona **in parallel** using the Agent tool. Each sub-agent receives:
+
+1. The **issue title and description**
+2. All **context** gathered (comments, branch diff, codebase snippets)
+3. The persona's **identity prompt**
+
+**Sub-agent prompt template:**
+
+```
+You are {name}, a {role}.
+
+Your perspective: {perspective}
+Your natural bias: {bias}
+
+You are reviewing an issue before implementation. Here is the issue:
+
+**Title:** {issue_title}
+**Description:** {issue_description}
+**Comments:** {issue_comments}
+
+Codebase context:
+{codebase_context}
+
+{branch_diff_context_if_any}
+
+As {name}, provide your review:
+1. **Feasibility:** Is this issue feasible as described? What's missing or unclear?
+2. **Risks:** What are the top 2-3 risks? Be specific about failure scenarios from your domain.
+3. **Completeness:** Are acceptance criteria clear enough to implement? What questions would you ask the PO?
+4. **Architecture/Design:** How should this be approached technically? What patterns or constraints apply?
+5. **Pushback:** What would you challenge from other typical perspectives?
+
+Stay fully in character. Be concise and actionable. Use concrete examples, not abstract platitudes.
+
+This is a research task — do NOT write or edit any files.
+```
+
+**Launch ALL persona sub-agents in a single message** so they run in parallel. Use `subagent_type: "general-purpose"` and a short description like `"Review persona: {name}"`.
+
+**Collect all positions** and present them as quotes:
+
+> **SOLID Alex (Senior Backend Engineer):** "I think..."
+
+#### Anti-Groupthink Check
+
+After collecting Round 1 responses, evaluate the consensus level:
+
+1. **Check if all personas converged on the same assessment** (same verdict, no meaningful disagreement)
+2. **If consensus is too high** (all personas agree with no pushback):
+   - Launch **one additional sub-agent** as a devil's advocate:
+     ```
+     You are a devil's advocate reviewing an issue.
+
+     All reviewers agreed on this assessment: {consensus_summary}
+
+     Your job: find the strongest possible argument AGAINST this consensus.
+     - What risk did nobody mention?
+     - What assumption are they all making that might be false?
+     - What edge case or failure mode was dismissed too quickly?
+
+     Be specific and concrete. Reference real failure scenarios.
+     This is a research task — do NOT write or edit any files.
+     ```
+   - Include the dissenting view in the analysis
+3. **If there is already meaningful disagreement:** proceed directly to Round 2
+
+#### Round 2: Debate and Challenges (Parallel Sub-Agents)
+
+Launch a **second round of parallel sub-agents** — one per persona. Each sub-agent receives:
+
+1. The **issue details**
+2. The **full set of opening statements** from Round 1 (all personas)
+3. The persona's identity prompt
+
+**Sub-agent prompt template for Round 2:**
+
+```
+You are {name}, a {role}.
+
+Your perspective: {perspective}
+Your natural bias: {bias}
+
+You are in a review meeting about this issue:
+
+**Title:** {issue_title}
+
+Here are the opening statements from all reviewers:
+{all_opening_statements}
+
+As {name}, react to the other reviewers' positions:
+1. Which assessments do you agree with and why?
+2. Which assessments do you challenge? Be specific about what's wrong or missing.
+3. What risks or gaps have the others missed?
+4. Have any of the other statements changed your assessment? If so, how?
+5. State your updated verdict: is this issue ready for implementation, needs adjustments, or needs a rethink?
+
+Be direct and create genuine debate. Challenge assumptions. Reference specific points from the other statements. It's OK to disagree strongly. It's also OK to change your mind if convinced.
+
+This is a research task — do NOT write or edit any files.
+```
+
+**Launch ALL persona sub-agents in a single message** for Round 2.
+
+**This round should produce genuine tension.** If the sub-agents all agree, add a follow-up prompt to one agent asking it to play devil's advocate on the majority position.
+
+#### Round 3: Weighted Convergence
+
+After collecting all Round 2 responses, **you** (the facilitator, not a sub-agent) synthesize the discussion:
+
+1. **Weight positions by domain relevance:**
+   - For each persona, assess how central the issue is to their expertise
+   - A database migration issue: EXPLAIN PLAN Isabelle's position carries more weight than Pixel-Perfect Hugo's
+   - A UI redesign issue: Pixel-Perfect Hugo's position carries more weight than EXPLAIN PLAN Isabelle's
+
+2. **Identify consensus and disagreements:**
+   - Points of agreement across all personas
+   - Unresolved disagreements — list them explicitly
+   - Key risks and gaps that emerged from the debate
+
+3. **Assess the issue readiness:**
+   - **Ready for implementation:** Well-defined, feasible, risks are manageable
+   - **Needs adjustments:** Feasible but missing details, unclear acceptance criteria, or risks need mitigation
+   - **Needs significant rework:** Major gaps, unclear scope, architectural concerns unresolved
+
+4. **Compile actionable next steps** — concrete checklist items the team can act on
+
+### Step 5: Produce the Review Analysis
+
+Write a structured analysis displayed to the user:
+
+```markdown
+## Revue d'issue par personas IA
+
+**Issue :** #XX — [titre de l'issue]
+
+**Participants :** [Name (Role)] | [Name (Role)] | [Name (Role)]
+
+### Contexte
+[Résumé métier de l'issue — ce que l'utilisateur/patient/équipe gagne]
+
+### Synthèse de la revue
+
+#### Faisabilité
+[Assessment: faisable en l'état / faisable avec réserves / nécessite clarification]
+
+#### Complétude
+[Are acceptance criteria clear? What's missing from the spec?]
+
+#### Risques identifiés
+- [Risque 1 en impact métier → Mitigation]
+- [Risque 2 en impact métier → Mitigation]
+
+#### Points techniques à considérer
+[Only when personas surfaced architecture/security/performance concerns — omit section if none]
+
+### Prochaines étapes recommandées
+- [ ] [Action 1 — e.g., "Préciser les critères d'acceptation pour le cas X"]
+- [ ] [Action 2 — e.g., "Valider l'impact sur le module Y avec l'équipe"]
+- [ ] [Action 3]
+
+### Verdict
+[One of: ✅ Prête pour implémentation / ⚠️ Nécessite des ajustements avant implémentation / ❌ Nécessite une refonte significative]
+```
+
+### Step 6: Post to Issue
+
+Post the review analysis as a comment on the issue. The comment uses the same structure as Step 5, with a footer.
+
+#### Comment Template (French — PO / Consultant Oriented with Technical Concerns)
+
+```markdown
+## Revue d'issue par personas IA
+
+### Contexte
+[Résumé métier de l'issue — ce que l'utilisateur/patient/équipe gagne]
+
+### Participants
+| Expert | Rôle | Verdict |
+|--------|------|---------|
+| [Name] | [Role] | [Position résumée en 1 ligne orientée impact métier] |
+| ... | ... | ... |
+
+### Synthèse de la revue
+
+#### Faisabilité
+[Assessment formulé en termes d'impact métier et de faisabilité technique]
+
+#### Complétude
+[Analyse de la complétude des critères d'acceptation et des cas d'usage décrits]
+
+#### Risques identifiés
+- [Risque 1 en impact métier → Mitigation proposée]
+- [Risque 2 en impact métier → Mitigation proposée]
+
+#### Points techniques à considérer
+[Uniquement si des préoccupations architecture/sécurité/performance ont émergé — omettre cette section si aucun point technique notable]
+
+### Prochaines étapes recommandées
+- [ ] [Action 1]
+- [ ] [Action 2]
+- [ ] [Action 3]
+
+### Verdict
+[✅ Prête pour implémentation / ⚠️ Nécessite des ajustements avant implémentation / ❌ Nécessite une refonte significative]
+
+---
+_Revue générée automatiquement par IA_
+```
+
+Post the comment using the appropriate tool:
+- **GitLab:** `glab issue note <iid> --message "<comment>"`
+- **GitHub:** `gh issue comment <number> --body "<comment>"`
+
+If posting fails (API error, permission denied):
+- Output the full review comment in the conversation so nothing is lost
+- Provide a manual command the user can paste to post the comment themselves
+- Record the failure in the Run Summary
+
+### Step 7: Run Summary
+
+**Always output a structured run summary at the end**, regardless of whether the pipeline succeeded or failed.
+
+```markdown
+### Issue Review — Run Summary
+- **Issue :** #XX — [titre]
+- **Remote :** GitLab / GitHub
+- **Personas :** [Name (Role)] | [Name (Role)] | [Name (Role)]
+- **Rounds :** 3 (ouverture + débat + convergence)
+- **Anti-groupthink :** déclenché / non nécessaire
+- **Verdict :** ✅ Prête / ⚠️ Ajustements / ❌ Refonte
+- **Commentaire :** publié (#XX) / échec ([raison])
+- **Durée totale :** [durée wall-clock]
+```
+
+## Edge Cases
+
+### Minimal or Empty Issue
+
+If the issue has no description or only a one-line title with no meaningful content:
+
+1. **Do NOT run the persona meeting** — there is not enough content to review
+2. **Post a short comment in French** on the issue listing what's missing:
+
+```markdown
+## Revue d'issue — Contenu insuffisant
+
+Cette issue ne contient pas assez d'informations pour réaliser une revue pertinente.
+
+### Éléments manquants
+- [ ] Description détaillée du besoin ou du problème
+- [ ] Critères d'acceptation
+- [ ] Contexte métier (qui est impacté, quel workflow)
+- [ ] [Any other specific gaps detected]
+
+Merci de compléter l'issue puis de relancer la revue.
+
+---
+_Revue générée automatiquement par IA_
+```
+
+3. Output the same message in the conversation and stop
+
+### Closed Issue
+
+If the issue is closed:
+
+1. **Warn the user:** "Cette issue est fermée. Souhaitez-vous quand même lancer la revue ? (utile pour une rétrospective)"
+2. **If the user confirms:** proceed normally
+3. **If the user declines or does not respond:** stop
+
+### Posting Failure
+
+If the comment cannot be posted to the issue:
+- Output the full review in the conversation
+- Provide a pre-formatted manual command
+- Record the failure in the Run Summary
+
+## Meeting Quality Rules
+
+### Persona Authenticity
+- Each persona speaks consistently with their role and bias
+- Personas use concrete examples, not abstract platitudes
+- A security engineer talks about attack vectors, not vague "security concerns"
+- A product owner talks about user impact and delivery timelines, not code patterns
+
+### Debate Quality
+- At least one persona must disagree with the majority
+- Arguments must reference specific trade-offs (performance vs. maintainability, speed vs. safety)
+- Avoid false consensus — if everyone agrees too quickly, the anti-groupthink check triggers a devil's advocate
+- Personas can change their mind during the debate if convinced
+
+### Review Quality
+- The review must be actionable, not vague
+- Risks must include mitigation strategies
+- Next steps must be concrete and checkboxable
+- The verdict must be one of the three defined levels (ready / needs adjustments / needs rework)
+- The analysis is written in French (natural, professional, using "nous")
+
+## Examples
+
+### Example 1: Well-Defined Feature Issue
+
+```
+User: issue-review #42
+
+→ Fetch issue #42 (feature: add patient notification system)
+→ Fetch all comments (3 comments with PO clarifications)
+→ No linked branch
+→ Explore codebase: notification module, patient service, event system
+→ Auto-select: SOLID Alex (Backend), Whiteboard Damien (Architecte), Sprint Zero Sarah (PO), Paranoid Shug (Sécurité)
+→ Run 3-round review meeting
+→ Verdict: ⚠️ Nécessite des ajustements (missing acceptance criteria for notification preferences)
+→ Post review comment on issue #42
+```
+
+### Example 2: Issue with Linked Branch
+
+```
+User: issue-review https://github.com/org/repo/issues/15
+
+→ Fetch issue #15 (bug: patient search returns duplicates)
+→ Fetch comments (1 comment with reproduction steps)
+→ Linked branch: fix/patient-search-duplicates — fetch diff
+→ Explore codebase: search service, patient repository, index configuration
+→ Auto-select: SOLID Alex (Backend), EXPLAIN PLAN Isabelle (DBA), Edge-Case Nico (QA)
+→ Run 3-round review meeting
+→ Verdict: ✅ Prête pour implémentation
+→ Post review comment on issue #15
+```
+
+### Example 3: Incomplete Issue
+
+```
+User: issue-review #99
+
+→ Fetch issue #99 (title only: "Fix the thing")
+→ No description, no comments
+→ Skip meeting — post "contenu insuffisant" comment
+→ List missing elements on issue #99
+```
+
+### Example 4: Closed Issue (Retrospective)
+
+```
+User: issue-review #30
+
+→ Fetch issue #30 (closed)
+→ Warn user: "Cette issue est fermée. Souhaitez-vous quand même lancer la revue ?"
+→ User confirms
+→ Proceed with full review pipeline
+→ Post review comment on issue #30
+```
+
+## Important Notes
+
+- **Never create new labels** on GitLab or GitHub. Only use labels that already exist in the project. If no suitable label exists, skip labeling.
+- **This skill is analytical only** — it does NOT implement code, create branches, or create MRs/PRs
+- **The review comment is always in French**, PO/consultant oriented, with technical concerns surfaced when needed
+- The codebase is always explored for context, even when no branch is linked
+- The meeting runs 3 full rounds (opening + debate + convergence) for review depth
+- If the remote type cannot be determined, default to `gh issue comment` (GitHub)
+- The skill supports both GitLab and GitHub issues

--- a/skills/issue-review/reference/personas.md
+++ b/skills/issue-review/reference/personas.md
@@ -1,0 +1,24 @@
+<!-- Canonical persona pool. Keep in sync with skills/meeting/reference/personas.md -->
+
+# Persona Pool
+
+| Persona | Rôle | Perspective | Biais |
+|---------|------|-------------|-------|
+| **SOLID Alex** | Développeur Backend Senior | Qualité du code, maintenabilité, dette technique, design patterns | Patrons éprouvés, prudent face aux nouvelles technos |
+| **Sprint Zero Sarah** | Product Owner | Valeur utilisateur, rapidité de livraison, impact métier | Livre vite, compromis pragmatiques |
+| **Paranoid Shug** | Ingénieur Sécurité (OWASP) | Surface d'attaque, OWASP Top 10, OAuth2/OIDC/JWT, secure coding | Option la plus sécurisée, suppose une entrée hostile |
+| **Pipeline Mo** | Ingénieur DevOps/SRE | Opérabilité, CI/CD, Docker/K8s, IaC, observabilité | Infra simple, systèmes observables, exige un plan de rollback |
+| **Pixel-Perfect Hugo** | Développeur Frontend | UX, performance frontend, Vue.js, React, PrimeVue, shadcn/ui | Centré utilisateur, systèmes de composants UI cohérents |
+| **Whiteboard Damien** | Tech Lead / Architecte | Conception système, arbitrages, contrats d'API, modèle C4 | Architecture durable, schéma avant code |
+| **Edge-Case Nico** | Ingénieur QA | Testabilité, cas limites, régression, Playwright, Vitest | Couverture exhaustive, pipelines de tests automatisés |
+| **EXPLAIN PLAN Isabelle** | DBA Oracle | Oracle 11.2-19c+, PL/SQL, tuning, RAC, Data Guard | Schéma robuste, performance des requêtes, intégrité des données |
+| **Schema JB** | Data Engineer | Intégrité des données, ETL, migrations, lignage/gouvernance | Stabilité du schéma, exige un script de rollback |
+| **RFC Santiago** | PO Interopérabilité | Standards HL7, FHIR, HPK, intégration inter-systèmes | Basé sur les standards, protège l'amont et l'aval |
+| **Legacy Larry** | Spécialiste Uniface | Applications Uniface, modernisation legacy, 4GL/RAD, UI pilotée par la BDD | Évolution pragmatique plutôt que réécriture |
+| **HL7 Victor** | Développeur Fullstack Interop | Parsing HL7/FHIR/HPK, middleware, mapping de données | Full-stack pragmatique, fait le pont entre standards et implémentation |
+| **RGPD Raphaël** | DPO / Conformité | RGPD, HDS, données patient, consentement, pistes d'audit | Option la plus conforme, averse au risque juridique |
+| **Dr. Workflow Wendy** | Experte Domaine Santé | Workflows hospitaliers, administration patient, cas d'usage cliniques | Colle à la réalité clinique, résiste aux approches tech-first |
+| **Figma Fiona** | Designer UX/UI | Recherche utilisateur, design tokens, WCAG, architecture de l'information | Design-first, exige une validation utilisateur |
+| **Dashboard Estelle** | Senior BI / Data Analyst — Finance & Comptabilité | Reporting financier, comptabilité analytique, balance âgée, datatables complexes, filtres avancés, Cognos, Power BI, Business Objects | Exige des KPIs actionnables et des interfaces exploitables par les contrôleurs de gestion |
+
+**Personas personnalisés :** Si le sujet est spécifique à un domaine (santé, finance, juridique...), créer un persona expert du domaine concerné.


### PR DESCRIPTION
## Summary
- Add new `issue-review` skill for reviewing GitLab/GitHub issues
- Rename `gitlab-code-review` to `code-review` for broader applicability
- Improve documentation quality across multiple skill docs (healthcare parsers, HPK, PDF, etc.)
- Clean up oversized reference docs (`hpk-adt-message.md`, `specification-hpk-gef.md`)

## Test plan
- [ ] Verify `issue-review` skill loads correctly via `npx skills`
- [ ] Verify `code-review` skill works after rename
- [ ] Check documentation links are consistent

🤖 Generated with [Claude Code](https://claude.com/claude-code)