### PR TITLE
feat(setup): add unified setup skill + ## Prerequisites convention across all skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ graph LR
 | **playwright-skill** | Automatisation navigateur et tests web | [doc](docs/playwright-skill.md) |
 | **postgres** | Requêtes SQL lecture seule sur PostgreSQL | [doc](docs/postgres.md) |
 | **mcp-builder** | Création de serveurs MCP | [doc](docs/mcp-builder.md) |
+| **setup** | Installation des outils CLI, auth GitHub/GitLab, config Jira MCP | [doc](docs/setup.md) |
 | **write-a-skill** | Guide pour créer un nouveau skill | [doc](docs/write-a-skill.md) |
 
 ## Ressources

--- a/docs/comment-utiliser.md
+++ b/docs/comment-utiliser.md
@@ -17,7 +17,7 @@ Guide pour installer et utiliser les skills avec vos assistants IA (GitHub Copil
 > setup
 > ```
 >
-> Voir [docs/setup.md](setup.md) pour le détail.
+> Voir [setup.md](setup.md) pour le détail.
 
 ## Installation
 

--- a/docs/comment-utiliser.md
+++ b/docs/comment-utiliser.md
@@ -11,6 +11,14 @@ Guide pour installer et utiliser les skills avec vos assistants IA (GitHub Copil
   - VS Code : ouvrir les settings (`Ctrl+,`) et rechercher "agent skills"
   - Cursor / Windsurf : vérifier dans les préférences
 
+> **Après l'installation**, lancez le skill `setup` pour installer automatiquement les outils CLI prérequis (`gh`, `glab`, `jq`, `uvx`) et configurer l'intégration Jira :
+>
+> ```
+> setup
+> ```
+>
+> Voir [docs/setup.md](setup.md) pour le détail.
+
 ## Installation
 
 ### Installation globale (tous les skills)

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -1,0 +1,91 @@
+# Skill : setup
+
+Configure votre environnement de développement en une seule commande : installe les outils CLI prérequis, guide l'authentification GitHub/GitLab, et configure l'intégration Jira (MCP) pour OpenCode.
+
+## Ce que fait ce skill
+
+| Phase | Actions |
+|-------|---------|
+| 1 — Outils CLI | Installe `gh`, `glab`, `jq`, `uvx` via apt/curl (si absents) |
+| 2 — Authentification | Vérifie et guide la connexion à GitHub et GitLab |
+| 3 — Jira MCP | Configure `mcp-atlassian` dans `~/.config/opencode/opencode.json` |
+| 4 — Résumé | Affiche le statut de chaque composant |
+
+Le skill est **idempotent** : relancer ne réinstalle pas ce qui est déjà présent.
+
+## Déclenchement
+
+Dites à votre assistant IA :
+
+```
+setup
+```
+
+ou
+
+```
+install prerequisites
+```
+
+ou encore :
+
+```
+configure jira
+```
+
+## Détail des installations
+
+### Outils CLI (Phase 1)
+
+Gérés par le script `reference/setup.sh` :
+
+- **`gh`** — GitHub CLI : création d'issues, PR, releases
+- **`glab`** — GitLab CLI : merge requests, issues GitLab
+- **`jq`** — processeur JSON : requis par plusieurs skills (git-guardrails, etc.)
+- **`uvx`** — runner de paquets Python (via `uv`) : requis pour `mcp-atlassian`
+
+### Authentification (Phase 2)
+
+Le skill vérifie l'état de connexion et vous indique les commandes à exécuter si nécessaire :
+
+```bash
+gh auth login    # GitHub
+glab auth login  # GitLab
+```
+
+Ces commandes requièrent une interaction manuelle — le skill vous guide mais ne les exécute pas automatiquement.
+
+### Configuration Jira MCP (Phase 3)
+
+Le skill configure le serveur MCP `mcp-atlassian` dans votre fichier OpenCode (`~/.config/opencode/opencode.json`).
+
+Vous aurez besoin :
+- De votre **URL Jira** (par défaut : `https://jira.dedalus.com/`)
+- D'un **Personal Access Token (PAT)** Jira :
+  1. Connectez-vous à votre instance Jira
+  2. Allez dans **Profil → Personal Access Tokens**
+  3. Cliquez sur **Create token**, donnez-lui un nom et une expiration
+  4. Copiez le token
+
+> **Jira Cloud** : utilisez un API Token depuis `https://id.atlassian.com/manage-profile/security/api-tokens` avec votre email (`JIRA_USERNAME` + `JIRA_API_TOKEN`) à la place du PAT.
+
+Une fois configuré, le fichier de config est sécurisé automatiquement (`chmod 600`).
+
+## Après la configuration
+
+Redémarrez OpenCode pour charger la nouvelle configuration MCP. Vous pouvez ensuite demander à votre assistant :
+
+```
+Lis le ticket HEX-5945
+Liste mes tickets ouverts dans le projet HEX
+```
+
+## Dépendances
+
+Aucun skill prérequis. Ce skill est conçu pour être la première chose à lancer après l'installation des Foundation Skills.
+
+## Voir aussi
+
+- [`gitlab-issue`](gitlab-issue.md) — gestion des issues GitLab (nécessite `glab`)
+- [`github-issues`](github-issues.md) — gestion des issues GitHub (nécessite `gh`)
+- [`git-guardrails`](git-guardrails.md) — protection des commandes git dangereuses (nécessite `jq`)

--- a/skills/_TEMPLATE/SKILL.md
+++ b/skills/_TEMPLATE/SKILL.md
@@ -11,6 +11,12 @@ metadata:
 
 Brief description of the skill's purpose.
 
+## Prerequisites
+
+<!-- Remove this section if the skill has no external tool dependencies -->
+
+- **tool-name**: description — install with `<install command>`
+
 ## When to Use This Skill
 
 Activate when the user:

--- a/skills/article-extractor/SKILL.md
+++ b/skills/article-extractor/SKILL.md
@@ -2,7 +2,7 @@
 name: article-extractor
 description: "Extraire le contenu propre d'articles depuis des URLs (billets de blog, articles, tutoriels) et sauvegarder en texte lisible. À utiliser quand l'utilisateur veut télécharger, extraire ou sauvegarder un article/billet de blog depuis une URL sans publicités, navigation ou encombrement."
 allowed-tools: Bash,Write
-version: 1.0.0
+version: 1.0.1
 license: MIT
 metadata:
   author: Foundation Skills
@@ -11,6 +11,14 @@ metadata:
 # Article Extractor
 
 This skill extracts the main content from web articles and blog posts, removing navigation, ads, newsletter signups, and other clutter. Saves clean, readable text.
+
+## Prerequisites
+
+At least one of:
+- **Node.js 18+ and npm** — required for `reader` (`npm install -g reader-cli`)
+- **Python 3 and pip** — required for `trafilatura` (`pip3 install trafilatura`)
+
+If neither is installed, the skill falls back to a basic `curl`-based extraction (no install needed).
 
 ## When to Use This Skill
 

--- a/skills/code-review/SKILL.md
+++ b/skills/code-review/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: code-review
 description: "Effectue des revues de code complètes des merge requests GitLab, analysant la qualité du code, la sécurité, les performances et les bonnes pratiques. À utiliser quand l'utilisateur dit « code review » ou demande de revoir des merge requests ou d'analyser les changements d'une branche avant fusion."
-version: 2.0.0
+version: 2.1.0
 license: MIT
 metadata:
   author: Foundation Skills
@@ -10,6 +10,10 @@ metadata:
 # Code Review
 
 Perform comprehensive code reviews of GitLab merge requests, providing actionable feedback on code quality, security, performance, and best practices.
+
+## Prerequisites
+
+- **glab** (GitLab CLI): required for all MR and pipeline operations — install from https://gitlab.com/gitlab-org/cli or `brew install glab`
 
 ## GitLab Instance Configuration
 

--- a/skills/fast-meeting/SKILL.md
+++ b/skills/fast-meeting/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: fast-meeting
 description: "Lance une réunion autonome rapide avec des personas sélectionnés automatiquement, implémente la décision, crée une MR/PR, commite, pousse et publie un résumé en français — le tout sans intervention de l'utilisateur."
-version: 1.6.0
+version: 1.7.0
 license: MIT
 metadata:
   author: Foundation Skills
@@ -10,6 +10,11 @@ metadata:
 # Fast Meeting
 
 Run a fully autonomous meeting with expert personas, then immediately implement the recommended solution, create a merge request or pull request, and post a French description — all without asking the user for confirmation.
+
+## Prerequisites
+
+- **gh** (GitHub CLI): required when the project uses GitHub — install from https://cli.github.com or `brew install gh`
+- **glab** (GitLab CLI): required when the project uses GitLab — install from https://gitlab.com/gitlab-org/cli or `brew install glab`
 
 ## When to Use This Skill
 

--- a/skills/git-guardrails/SKILL.md
+++ b/skills/git-guardrails/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: git-guardrails
 description: "Configure des hooks Claude Code pour bloquer les commandes git dangereuses (push, force-push, reset --hard, clean, branch -D, checkout/restore) avant leur exécution. Empêche les opérations git destructrices au niveau de l'agent."
-version: 1.0.0
+version: 1.1.0
 license: MIT
 metadata:
   author: Foundation Skills
@@ -11,6 +11,11 @@ metadata:
 # Git Guardrails
 
 Sets up a PreToolUse hook that intercepts and blocks dangerous git commands before Claude Code executes them.
+
+## Prerequisites
+
+- **jq**: required for the hook script to parse tool input — install with `brew install jq` or `apt-get install jq`
+  - **Important:** if `jq` is not installed, the hook will **fail open** (allow all commands). Always verify `jq` is available after setup.
 
 ## When to Use This Skill
 

--- a/skills/github-issues/SKILL.md
+++ b/skills/github-issues/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: github-issues
 description: "Crée, récupère, met à jour et gère les issues GitHub avec collecte complète du contexte. À utiliser quand l'utilisateur veut créer une nouvelle issue, voir les détails d'une issue, mettre à jour des issues existantes, lister les issues du projet, ajouter des commentaires ou gérer les workflows d'issues dans GitHub."
-version: 1.1.0
+version: 1.2.0
 license: MIT
 metadata:
   author: Foundation Skills
@@ -10,6 +10,10 @@ metadata:
 # GitHub Issues Management
 
 Create, retrieve, update, and manage GitHub issues with comprehensive context integration and structured workflows.
+
+## Prerequisites
+
+- **gh** (GitHub CLI): required for all issue operations — install from https://cli.github.com or `brew install gh`
 
 ## When to Use This Skill
 

--- a/skills/gitlab-issue/SKILL.md
+++ b/skills/gitlab-issue/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: gitlab-issue
 description: "Crée, récupère, met à jour et gère les issues GitLab avec collecte complète du contexte. À utiliser quand l'utilisateur veut créer une nouvelle issue, voir les détails d'une issue, mettre à jour des issues existantes, lister les issues du projet ou gérer les workflows d'issues dans GitLab."
-version: 1.1.0
+version: 1.2.0
 license: MIT
 metadata:
   author: Foundation Skills
@@ -10,6 +10,10 @@ metadata:
 # GitLab Issue Management
 
 Create, retrieve, update, and manage GitLab issues with comprehensive context integration and structured workflows.
+
+## Prerequisites
+
+- **glab** (GitLab CLI): required for all issue operations — install from https://gitlab.com/gitlab-org/cli or `brew install glab`
 
 ## GitLab Instance Configuration
 

--- a/skills/issue-review/SKILL.md
+++ b/skills/issue-review/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: issue-review
 description: "Lance une revue d'issue automatique avec des personas experts sélectionnés automatiquement, analyse la faisabilité, la complétude, les risques et l'architecture, puis publie un rapport structuré directement sur l'issue — le tout sans intervention de l'utilisateur."
-version: 1.0.0
+version: 1.1.0
 license: MIT
 metadata:
   author: Foundation Skills
@@ -10,6 +10,11 @@ metadata:
 # Issue Review
 
 Run a fully autonomous multi-angle review of a GitLab or GitHub issue using expert personas. The skill fetches issue context, explores the relevant codebase, runs a 3-round persona meeting (opening statements, debate, weighted convergence), and posts a structured review comment directly on the issue — all without asking the user for confirmation.
+
+## Prerequisites
+
+- **gh** (GitHub CLI): required when the project uses GitHub — install from https://cli.github.com or `brew install gh`
+- **glab** (GitLab CLI): required when the project uses GitLab — install from https://gitlab.com/gitlab-org/cli or `brew install glab`
 
 ## When to Use This Skill
 

--- a/skills/meeting/SKILL.md
+++ b/skills/meeting/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: meeting
 description: "Lance une réunion simulée avec plusieurs personas experts pour analyser un sujet sous des perspectives diverses, prendre une décision et proposer une solution avant implémentation. Peut optionnellement publier l'analyse de la réunion sur une issue GitLab ou GitHub liée."
-version: 1.3.0
+version: 1.4.0
 license: MIT
 metadata:
   author: Foundation Skills
@@ -10,6 +10,11 @@ metadata:
 # Meeting
 
 Simulate a structured meeting with multiple expert personas to analyze a subject, debate perspectives, and converge on the best course of action. The output is a decision-ready analysis that the user validates before any implementation begins.
+
+## Prerequisites
+
+- **gh** (GitHub CLI): required when posting meeting results to GitHub issues — install from https://cli.github.com or `brew install gh`
+- **glab** (GitLab CLI): required when posting meeting results to GitLab issues — install from https://gitlab.com/gitlab-org/cli or `brew install glab`
 
 ## When to Use This Skill
 

--- a/skills/playwright-skill/SKILL.md
+++ b/skills/playwright-skill/SKILL.md
@@ -1,13 +1,18 @@
 ---
 name: playwright-skill
 description: "Automatisation complète du navigateur et tests web avec Playwright. Détecte automatiquement les serveurs de développement, gère le cycle de vie des serveurs, écrit des scripts de test propres dans /tmp. Tester des pages, remplir des formulaires, capturer des screenshots, vérifier le responsive design, valider l'UX, tester les flux de connexion, vérifier les liens, déboguer des webapps dynamiques, automatiser toute tâche navigateur. À utiliser quand l'utilisateur veut tester des sites web, automatiser des interactions navigateur, valider des fonctionnalités web ou effectuer tout test basé sur le navigateur."
-version: 1.0.0
+version: 1.1.0
 license: MIT
 ---
 
 # Playwright Web Testing & Automation
 
 Comprehensive web testing skill using Playwright. Write custom JavaScript code for any testing or automation task.
+
+## Prerequisites
+
+- **Node.js**: required — install from https://nodejs.org
+- **playwright** npm package: `npm install playwright` (installs headless Chromium automatically)
 
 ## Decision Tree: Choosing Your Approach
 

--- a/skills/postgres/SKILL.md
+++ b/skills/postgres/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: postgres
 description: "Exécute des requêtes SQL en lecture seule sur plusieurs bases de données PostgreSQL. À utiliser pour : (1) interroger des bases PostgreSQL, (2) explorer les schémas/tables, (3) exécuter des requêtes SELECT pour l'analyse de données, (4) vérifier le contenu des bases. Supporte plusieurs connexions avec descriptions pour une sélection automatique intelligente. Bloque toutes les opérations d'écriture (INSERT, UPDATE, DELETE, DROP, etc.) par sécurité."
-version: 1.0.0
+version: 1.0.1
 license: MIT
 ---
 
@@ -9,7 +9,7 @@ license: MIT
 
 Execute safe, read-only queries against configured PostgreSQL databases.
 
-## Requirements
+## Prerequisites
 
 - Python 3.8+
 - psycopg2-binary: `pip install -r requirements.txt`

--- a/skills/setup/SKILL.md
+++ b/skills/setup/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: setup
 description: "Installe les outils CLI prérequis (gh, glab, jq), guide l'authentification GitHub/GitLab, installe uvx et configure le serveur MCP mcp-atlassian pour Jira dans OpenCode. Idempotent : relancer le skill est sans danger. Déclenché quand l'utilisateur dit « setup », « install prerequisites » ou « configurer jira »."
-version: 1.0.0
+version: 1.0.1
 license: MIT
 ---
 
@@ -18,6 +18,8 @@ Install CLI tools, authenticate to GitHub/GitLab, and configure the `mcp-atlassi
 ## Trigger
 
 User says: "setup", "install prerequisites", "configure jira", or similar.
+
+> **Important — interactive skill only.** This skill requires user interaction (auth prompts, Jira credentials). It must **not** be called as a sub-step from autonomous skill pipelines (fast-meeting, issue-review, etc.) — doing so will stall the pipeline waiting for input that will never arrive.
 
 ---
 
@@ -47,6 +49,7 @@ Check and authenticate each CLI:
 gh auth status 2>&1
 ```
 
+- Show the full output to the user (current logged-in account, token scopes, etc.)
 - If not authenticated → tell the user: "Run `gh auth login` and follow the prompts."
 - Do NOT run `gh auth login` automatically (requires interactive input).
 
@@ -54,6 +57,7 @@ gh auth status 2>&1
 glab auth status 2>&1
 ```
 
+- Show the full output to the user (GitLab instance, current user, token validity, etc.)
 - If not authenticated → tell the user: "Run `glab auth login` and follow the prompts."
 - Do NOT run `glab auth login` automatically.
 

--- a/skills/setup/SKILL.md
+++ b/skills/setup/SKILL.md
@@ -1,0 +1,151 @@
+---
+name: setup
+description: "Installe les outils CLI prérequis (gh, glab, jq), guide l'authentification GitHub/GitLab, installe uvx et configure le serveur MCP mcp-atlassian pour Jira dans OpenCode. Idempotent : relancer le skill est sans danger. Déclenché quand l'utilisateur dit « setup », « install prerequisites » ou « configurer jira »."
+version: 1.0.0
+license: MIT
+---
+
+# Setup — Prerequisites & MCP Configuration
+
+Install CLI tools, authenticate to GitHub/GitLab, and configure the `mcp-atlassian` Jira integration for OpenCode.
+
+## Prerequisites
+
+- Linux with `apt` package manager
+- `bash` and `curl` available
+- Internet access (for apt packages and uv installer)
+
+## Trigger
+
+User says: "setup", "install prerequisites", "configure jira", or similar.
+
+---
+
+## Workflow
+
+### Phase 1 — Install CLI tools
+
+Run the bundled script to install missing tools (idempotent — skips already-installed ones):
+
+```bash
+bash "$(dirname "$0")/reference/setup.sh"
+```
+
+The script installs (via `apt` if not already present):
+- `gh` — GitHub CLI
+- `glab` — GitLab CLI
+- `jq` — JSON processor
+- `uvx` — via the official `uv` installer (`curl -LsSf https://astral.sh/uv/install.sh | sh`)
+
+After running, inform the user of what was installed vs. already present.
+
+### Phase 2 — CLI Authentication
+
+Check and authenticate each CLI:
+
+```bash
+gh auth status 2>&1
+```
+
+- If not authenticated → tell the user: "Run `gh auth login` and follow the prompts."
+- Do NOT run `gh auth login` automatically (requires interactive input).
+
+```bash
+glab auth status 2>&1
+```
+
+- If not authenticated → tell the user: "Run `glab auth login` and follow the prompts."
+- Do NOT run `glab auth login` automatically.
+
+### Phase 3 — Configure mcp-atlassian for Jira
+
+**Step 3.1 — Check if uvx is available:**
+
+```bash
+uvx --version 2>&1 || ~/.local/bin/uvx --version 2>&1
+```
+
+If not found, remind the user to restart their shell or source `~/.bashrc` / `~/.profile` after the Phase 1 script ran.
+
+**Step 3.2 — Read existing OpenCode config:**
+
+Use the Read tool to read `~/.config/opencode/opencode.json`.
+
+- If the file does not exist, treat it as `{}`.
+- If `mcp.mcp-atlassian` is already present → confirm to the user and skip the rest of Phase 3.
+
+**Step 3.3 — Gather credentials (if not already configured):**
+
+Ask the user these two questions in a single message:
+
+1. **Jira URL** — default `https://jira.dedalus.com/` (Server/Data Center). Press Enter to accept.
+2. **Jira Personal Access Token (PAT)** — steps to generate one:
+   - Log in to your Jira instance
+   - Go to **Profile → Personal Access Tokens**
+   - Click **Create token**, give it a name, set an expiry
+   - Copy the token and paste it here
+
+> For **Jira Cloud** users: use `JIRA_USERNAME` (your email) + `JIRA_API_TOKEN` (from https://id.atlassian.com/manage-profile/security/api-tokens) instead of a PAT.
+
+**Step 3.4 — Write the config:**
+
+Merge the `mcp-atlassian` block into `~/.config/opencode/opencode.json`, preserving any existing content. Use the Write tool to write the final JSON.
+
+For **Server/Data Center** (default):
+
+```json
+{
+  "mcp": {
+    "mcp-atlassian": {
+      "type": "local",
+      "command": ["uvx", "mcp-atlassian"],
+      "environment": {
+        "JIRA_URL": "<jira-url>",
+        "JIRA_PERSONAL_TOKEN": "<pat>"
+      },
+      "enabled": true
+    }
+  }
+}
+```
+
+For **Cloud** (if user specifies):
+
+```json
+{
+  "mcp": {
+    "mcp-atlassian": {
+      "type": "local",
+      "command": ["uvx", "mcp-atlassian"],
+      "environment": {
+        "JIRA_URL": "<jira-url>",
+        "JIRA_USERNAME": "<email>",
+        "JIRA_API_TOKEN": "<api-token>"
+      },
+      "enabled": true
+    }
+  }
+}
+```
+
+**Step 3.5 — Secure the config file:**
+
+```bash
+chmod 600 ~/.config/opencode/opencode.json
+```
+
+### Phase 4 — Summary
+
+Print a clear summary table:
+
+| Component | Status |
+|-----------|--------|
+| gh | installed / already ok |
+| glab | installed / already ok |
+| jq | installed / already ok |
+| uvx | installed / already ok |
+| gh auth | authenticated / action needed |
+| glab auth | authenticated / action needed |
+| mcp-atlassian | configured / already ok / skipped |
+
+End with: "Restart OpenCode to load the new MCP configuration."

--- a/skills/setup/reference/setup.sh
+++ b/skills/setup/reference/setup.sh
@@ -1,0 +1,99 @@
+#!/bin/bash
+# setup.sh
+# Installs prerequisite CLI tools for Foundation Skills on Linux (apt).
+# Idempotent: safe to run multiple times — skips already-installed tools.
+#
+# Tools installed:
+#   gh    — GitHub CLI
+#   glab  — GitLab CLI
+#   jq    — JSON processor
+#   uvx   — via the official uv installer (curl)
+
+set -euo pipefail
+
+INSTALLED=()
+SKIPPED=()
+
+# ── Helper ────────────────────────────────────────────────────────────────────
+
+apt_install() {
+  local pkg="$1"
+  local cmd="${2:-$1}"
+  if command -v "$cmd" &>/dev/null; then
+    SKIPPED+=("$cmd")
+  else
+    echo "→ Installing $pkg..."
+    sudo apt-get update -qq
+    sudo apt-get install -y "$pkg"
+    INSTALLED+=("$cmd")
+  fi
+}
+
+# ── Phase 1: jq (no extra repo needed) ───────────────────────────────────────
+
+apt_install jq
+
+# ── Phase 2: gh (GitHub CLI) ─────────────────────────────────────────────────
+
+if command -v gh &>/dev/null; then
+  SKIPPED+=(gh)
+else
+  echo "→ Installing gh (GitHub CLI)..."
+  sudo apt-get update -qq
+  sudo apt-get install -y gh 2>/dev/null || {
+    # Fallback: add the official GitHub CLI apt repo
+    curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
+      | sudo dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg
+    sudo chmod go+r /usr/share/keyrings/githubcli-archive-keyring.gpg
+    echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] \
+https://cli.github.com/packages stable main" \
+      | sudo tee /etc/apt/sources.list.d/github-cli.list > /dev/null
+    sudo apt-get update -qq
+    sudo apt-get install -y gh
+  }
+  INSTALLED+=(gh)
+fi
+
+# ── Phase 3: glab (GitLab CLI) ───────────────────────────────────────────────
+
+if command -v glab &>/dev/null; then
+  SKIPPED+=(glab)
+else
+  echo "→ Installing glab (GitLab CLI)..."
+  GLAB_VERSION=$(curl -s https://gitlab.com/api/v4/projects/34675721/releases \
+    | grep -oP '"tag_name":"\Kv[^"]+' | head -1)
+  GLAB_VERSION="${GLAB_VERSION:-v1.46.0}"
+  ARCH=$(dpkg --print-architecture)
+  curl -fsSL "https://gitlab.com/gitlab-org/cli/-/releases/${GLAB_VERSION}/downloads/glab_${GLAB_VERSION#v}_linux_${ARCH}.deb" \
+    -o /tmp/glab.deb
+  sudo apt-get install -y /tmp/glab.deb
+  rm -f /tmp/glab.deb
+  INSTALLED+=(glab)
+fi
+
+# ── Phase 4: uvx (via uv installer) ──────────────────────────────────────────
+
+if command -v uvx &>/dev/null || [ -x "${HOME}/.local/bin/uvx" ]; then
+  SKIPPED+=(uvx)
+else
+  echo "→ Installing uv / uvx..."
+  curl -LsSf https://astral.sh/uv/install.sh | sh
+  INSTALLED+=(uvx)
+  echo "NOTE: Add ~/.local/bin to your PATH if not already present:"
+  echo "  echo 'export PATH=\"\$HOME/.local/bin:\$PATH\"' >> ~/.bashrc && source ~/.bashrc"
+fi
+
+# ── Summary ───────────────────────────────────────────────────────────────────
+
+echo ""
+echo "──────────────────────────────────────"
+echo "  Setup complete"
+echo "──────────────────────────────────────"
+if [ ${#INSTALLED[@]} -gt 0 ]; then
+  echo "  Installed : ${INSTALLED[*]}"
+fi
+if [ ${#SKIPPED[@]} -gt 0 ]; then
+  echo "  Already ok: ${SKIPPED[*]}"
+fi
+echo ""
+echo "Next: authenticate with 'gh auth login' and 'glab auth login'"

--- a/skills/setup/reference/setup.sh
+++ b/skills/setup/reference/setup.sh
@@ -3,6 +3,10 @@
 # Installs prerequisite CLI tools for Foundation Skills on Linux (apt).
 # Idempotent: safe to run multiple times — skips already-installed tools.
 #
+# MAINTENANCE NOTE: This script is maintained manually.
+# When a new skill requires a new installable CLI tool, add it here.
+# See skills/write-a-skill/SKILL.md for the convention.
+#
 # Tools installed:
 #   gh    — GitHub CLI
 #   glab  — GitLab CLI

--- a/skills/triage-issue/SKILL.md
+++ b/skills/triage-issue/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: triage-issue
 description: "Trier un bug ou une issue en explorant le codebase pour trouver la cause racine, puis créer une issue GitLab ou GitHub avec un plan de correction basé sur le TDD. À utiliser quand l'utilisateur signale un bug, veut créer une issue, mentionne « triage » ou veut investiguer et planifier la correction d'un problème."
-version: 1.1.0
+version: 1.2.0
 license: MIT
 metadata:
   author: Foundation Skills
@@ -11,6 +11,11 @@ metadata:
 # Triage Issue
 
 Investigate a reported problem, find its root cause, and create a GitLab or GitHub issue with a TDD fix plan. This is a mostly hands-off workflow -- minimize questions to the user.
+
+## Prerequisites
+
+- **gh** (GitHub CLI): required when the project uses GitHub — install from https://cli.github.com or `brew install gh`
+- **glab** (GitLab CLI): required when the project uses GitLab — install from https://gitlab.com/gitlab-org/cli or `brew install glab`
 
 ## When to Use This Skill
 

--- a/skills/write-a-skill/SKILL.md
+++ b/skills/write-a-skill/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: write-a-skill
 description: "Guide la création d'un nouveau skill d'agent IA pour le dépôt foundation-skills. Génère le squelette du SKILL.md et du fichier docs, applique les conventions du dépôt (frontmatter, versionnage, structure). À utiliser quand l'utilisateur demande de créer un nouveau skill, écrire un skill, ajouter un skill ou générer le squelette d'un skill."
-version: 1.0.0
+version: 1.1.0
 license: MIT
 ---
 
@@ -48,6 +48,7 @@ version: 1.0.0
 - Use progressive disclosure: put detailed content in `reference/` files
 - Include concrete examples
 - No time-sensitive information
+- If the skill requires external CLI tools (e.g., `gh`, `glab`, `jq`, `playwright`), add a `## Prerequisites` section listing each tool with its install command
 
 ### Step 4: Create reference files (if needed)
 
@@ -86,6 +87,7 @@ See existing files in `docs/` for style reference.
 - [ ] No time-sensitive info, consistent terminology
 - [ ] Concrete examples included
 - [ ] Reference files only one level deep
+- [ ] If external CLI tools are required, a `## Prerequisites` section is present with install commands
 
 ## Versioning rules
 

--- a/skills/write-a-skill/SKILL.md
+++ b/skills/write-a-skill/SKILL.md
@@ -48,7 +48,7 @@ version: 1.0.0
 - Use progressive disclosure: put detailed content in `reference/` files
 - Include concrete examples
 - No time-sensitive information
-- If the skill requires external CLI tools (e.g., `gh`, `glab`, `jq`, `playwright`), add a `## Prerequisites` section listing each tool with its install command. If the tool is not already handled by `skills/setup/reference/setup.sh`, add it there too (the setup script is maintained manually).
+- If the skill requires external CLI tools (e.g., `gh`, `glab`, `jq`, `playwright`), add a `## Prerequisites` section listing each tool with its install command. If the tool is not already handled by `skills/setup/reference/setup.sh`, add it there and bump `setup`'s version (the setup script is maintained manually).
 
 ### Step 4: Create reference files (if needed)
 
@@ -88,7 +88,7 @@ See existing files in `docs/` for style reference.
 - [ ] Concrete examples included
 - [ ] Reference files only one level deep
 - [ ] If external CLI tools are required, a `## Prerequisites` section is present with install commands
-- [ ] If the tool is new (not yet in `setup.sh`), `skills/setup/reference/setup.sh` has been updated
+- [ ] If the skill requires a new CLI tool not already handled by `setup.sh`, add it to `skills/setup/reference/setup.sh` and bump `setup`'s version
 
 ## Versioning rules
 

--- a/skills/write-a-skill/SKILL.md
+++ b/skills/write-a-skill/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: write-a-skill
 description: "Guide la création d'un nouveau skill d'agent IA pour le dépôt foundation-skills. Génère le squelette du SKILL.md et du fichier docs, applique les conventions du dépôt (frontmatter, versionnage, structure). À utiliser quand l'utilisateur demande de créer un nouveau skill, écrire un skill, ajouter un skill ou générer le squelette d'un skill."
-version: 1.1.0
+version: 1.2.0
 license: MIT
 ---
 
@@ -48,7 +48,7 @@ version: 1.0.0
 - Use progressive disclosure: put detailed content in `reference/` files
 - Include concrete examples
 - No time-sensitive information
-- If the skill requires external CLI tools (e.g., `gh`, `glab`, `jq`, `playwright`), add a `## Prerequisites` section listing each tool with its install command
+- If the skill requires external CLI tools (e.g., `gh`, `glab`, `jq`, `playwright`), add a `## Prerequisites` section listing each tool with its install command. If the tool is not already handled by `skills/setup/reference/setup.sh`, add it there too (the setup script is maintained manually).
 
 ### Step 4: Create reference files (if needed)
 
@@ -88,6 +88,7 @@ See existing files in `docs/` for style reference.
 - [ ] Concrete examples included
 - [ ] Reference files only one level deep
 - [ ] If external CLI tools are required, a `## Prerequisites` section is present with install commands
+- [ ] If the tool is new (not yet in `setup.sh`), `skills/setup/reference/setup.sh` has been updated
 
 ## Versioning rules
 


### PR DESCRIPTION
## Résumé

Ce PR introduit le skill `setup`, point d'entrée unique pour configurer un environnement de développement complet après installation des Foundation Skills, et standardise la section `## Prerequisites` sur l'ensemble du dépôt.

---

## Nouveau skill : `setup`

Le skill `setup` est idempotent et couvre 4 phases :

| Phase | Ce qui se passe |
|-------|----------------|
| 1 — Outils CLI | Installe `gh`, `glab`, `jq` (apt) et `uvx` (curl) si absents |
| 2 — Authentification | Vérifie `gh auth` / `glab auth` et guide l'utilisateur |
| 3 — Jira MCP | Configure `mcp-atlassian` dans `~/.config/opencode/opencode.json` |
| 4 — Résumé | Tableau statut de chaque composant |

**Fichiers ajoutés :**
- `skills/setup/SKILL.md` (v1.0.0)
- `skills/setup/reference/setup.sh` — script bash idempotent
- `docs/setup.md` — documentation utilisateur en français

---

## Convention `## Prerequisites`

Standardisation de la section `## Prerequisites` sur 13 skills :

| Skill | Changement | Version |
|-------|-----------|---------|
| `write-a-skill` | Nouvelle règle de convention + item checklist | `1.0.0 → 1.2.0` |
| `_TEMPLATE` | Ajout section `## Prerequisites` | — |
| `gitlab-issue` | Ajout `glab` comme prérequis | bumped |
| `github-issues` | Ajout `gh` comme prérequis | bumped |
| `playwright-skill` | Ajout Node.js + playwright | bumped |
| `git-guardrails` | Ajout `jq` comme prérequis | bumped |
| `code-review` | Ajout `glab` comme prérequis | bumped |
| `triage-issue` | Ajout `gh` + `glab` | bumped |
| `issue-review` | Ajout `gh` + `glab` | bumped |
| `fast-meeting` | Ajout `gh` + `glab` | bumped |
| `meeting` | Ajout `gh` + `glab` | bumped |
| `postgres` | Renommage `## Requirements` → `## Prerequisites` | `1.0.0 → 1.0.1` |
| `article-extractor` | Nouvelle section `## Prerequisites` formelle | `1.0.0 → 1.0.1` |

---

## Mises à jour documentaires

- **`README.md`** — ligne `setup` ajoutée dans le tableau Outils
- **`docs/comment-utiliser.md`** — callout post-installation pointant vers `setup`

---

## Test

```bash
# Vérifier le skill
cat skills/setup/SKILL.md

# Vérifier le script (idempotent, safe à relancer)
bash skills/setup/reference/setup.sh

# Vérifier la doc
cat docs/setup.md
```