### PR TITLE
feat(meeting-report): add Teams transcript to meeting report skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ graph LR
 |-------|-------------|-----|
 | **meeting** | Réunion simulée avec personas experts | [doc](docs/meeting.md) |
 | **fast-meeting** | Réunion autonome rapide avec décision et MR/PR | [doc](docs/fast-meeting.md) |
+| **meeting-report** | Compte-rendu automatique en français depuis une transcription Teams (`.vtt`) — spécifique hexagone-monorepo | [doc](docs/meeting-report.md) |
 | **grill-me** | Interview approfondie pour valider un plan | [doc](docs/grill-me.md) |
 | **ubiquitous-language** | Extraction de glossaire DDD (domaine santé) | [doc](docs/ubiquitous-language.md) |
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -65,6 +65,7 @@ Index de la documentation disponible pour les Foundation Skills.
 | [triage-issue](triage-issue.md)               | Triage de bugs avec plan de fix TDD                           |
 | [meeting](meeting.md)                         | Réunion simulée avec personas experts                         |
 | [fast-meeting](fast-meeting.md)               | Réunion autonome rapide avec décision et MR/PR                |
+| [meeting-report](meeting-report.md)           | Compte-rendu automatique depuis une transcription Teams (.vtt) |
 
 ### Hexagone / Domaine santé
 

--- a/docs/meeting-report.md
+++ b/docs/meeting-report.md
@@ -1,0 +1,100 @@
+# Meeting Report
+
+Génération automatique de comptes-rendus de réunion en français à partir d'une transcription Microsoft Teams.
+
+## Contexte
+
+Rédiger un compte-rendu de réunion prend du temps : écouter ou relire la transcription, réorganiser les échanges par sujet, extraire les décisions, identifier les actions à mener. Ce skill automatise toute la chaîne à partir du fichier `.vtt` exporté depuis Teams, avec en option le rapport de présence `.csv`.
+
+**Spécifique au projet hexagone-monorepo.** Le compte-rendu est rangé automatiquement dans le bon sous-dossier de `docs/reports/` selon le domaine concerné.
+
+## Utilisation
+
+Déposer un ou deux chemins de fichiers dans le prompt :
+
+```
+crée un compte-rendu de cette transcription Teams /chemin/vers/reunion.vtt
+génère le compte-rendu /chemin/vers/reunion.vtt /chemin/vers/attendees.csv
+transforme cette transcription en rapport /chemin/vers/reunion.vtt
+```
+
+Le skill détecte les fichiers automatiquement grâce à leur extension (`.vtt` = transcription, `.csv` = présence).
+
+## Fonctionnement
+
+```mermaid
+graph LR
+    A[.vtt + .csv optionnel] --> B[Parse transcription]
+    B --> C[Classification domaine]
+    C --> D[Rewrite par sujet]
+    D --> E[Extraction actions]
+    E --> F[docs/reports/&lt;domaine&gt;/&lt;fichier&gt;.md]
+```
+
+## Domaines supportés
+
+Le skill classe automatiquement le compte-rendu dans le bon sous-dossier de `docs/reports/` :
+
+| Dossier | Contenu |
+|---|---|
+| `foundation/` | Réunions internes de l'équipe Foundation (sprint, rétro, point équipe, daily) |
+| `core/` | Sujets transversaux, architecture, LDAP, S3A, permissions, rôles |
+| `gap/` | Gestion Administrative Patient : admission, venue, séjour, facturation, portail patient, ROC, serveur d'actes, urgences, Diapason |
+| `grh/` | Ressources humaines : MyRHConnect, RH Dossier, paie, contrats |
+| `gef/` | Finance et achats : pharmacie, M21, contentieux, trésorerie, HA GHT, immobilisations |
+| `ui-ux/` | Design, maquettes, ateliers UX/UI, Figma, écrans, prototypes |
+
+Si la réunion couvre plusieurs domaines, le skill choisit le domaine **dominant** (celui avec le plus de signaux dans la transcription).
+
+## Convention de nommage
+
+- **Réunions Foundation** : `YYYY-MM-DD.md` (date seule — une réunion d'équipe par jour au maximum)
+- **Autres domaines** : `YYYY-MM-DD-<slug>.md` (slug généré à partir du sujet détecté)
+
+Le nom de fichier utilise toujours le format ISO `YYYY-MM-DD`, tandis que la date dans le corps du compte-rendu est au format français `DD/MM/YYYY`.
+
+## Format du compte-rendu
+
+Le compte-rendu respecte exactement la structure existante des rapports hexagone-monorepo :
+
+- **Titre** : `# Compte-rendu — <Type> <Sujet>`
+- **Métadonnées** : date (`DD/MM/YYYY`), organisateur identifié
+- **Participants** : liste simple séparée par des virgules
+- **Sections numérotées** par sujet, chacune avec `### Décisions` et, si pertinent, `### Point d'attention` et `### Problèmes identifiés`
+- **Table `## Actions`** à la fin du document (toujours présente, avec une ligne « Aucune action identifiée » si rien n'a été repéré)
+- **Diagrammes Mermaid** optionnels, uniquement si le contenu les rend utiles (workflows multi-étapes, arbres de décision)
+
+Pas de front-matter YAML, pas de métadonnées cachées.
+
+## Rewrite intelligent
+
+Le skill ne recopie pas la transcription — il la **réorganise par sujet** et en extrait les décisions :
+
+- **Accents corrigés** : les transcriptions `.vtt` Teams en français sont régulièrement incomplètes sur les accents
+- **Filler supprimé** : « euh », « du coup », « en fait », répétitions, hésitations
+- **Ton professionnel** en français, utilisation de « nous » ou de la voie impersonnelle
+- **Emphase `**gras**`** sur les termes-clés dans les décisions
+- **Longueur cible** : 800 à 1500 mots par compte-rendu
+
+## Gestion des participants
+
+Ordre de priorité pour identifier les participants :
+
+1. **Fichier `.csv` de présence Teams** — le skill extrait la colonne `Name`
+2. **Balises `<v Speaker Name>` dans le `.vtt`** — lecture des tags de voix si présents
+3. **Demande à l'utilisateur** — si la transcription est anonyme et qu'aucun fichier de présence n'est fourni, le skill s'arrête et demande la liste des participants avant d'écrire
+
+Le skill n'invente jamais de noms.
+
+## Comportement
+
+- Écrit le fichier directement dans `docs/reports/<domaine>/<fichier>.md`
+- **Ne commite pas** et ne pousse pas — la revue et le commit restent manuels
+- **N'écrase jamais** un compte-rendu existant ; si un fichier avec le même nom existe déjà, un suffixe numérique (`-2`, `-3`) est ajouté
+- **Pas de censure** — les réunions sont considérées comme internes et sûres, les noms et contenus sont conservés tels quels
+
+## Prérequis
+
+- Être dans le projet **hexagone-monorepo** (le skill suppose que `docs/reports/<domaine>/` existe pour les six domaines)
+- Avoir exporté la transcription `.vtt` depuis Teams
+- Optionnel : avoir exporté le rapport de présence `.csv` pour enrichir la section Participants

--- a/skills/meeting-report/SKILL.md
+++ b/skills/meeting-report/SKILL.md
@@ -1,0 +1,311 @@
+---
+name: meeting-report
+description: "Génère automatiquement un compte-rendu de réunion en français à partir d'une transcription Teams (.vtt) et optionnellement d'un rapport de présence (.csv). Spécifique au projet hexagone-monorepo. À utiliser quand l'utilisateur dépose un ou deux chemins de fichiers Teams dans le prompt et demande la génération d'un compte-rendu."
+allowed-tools: Read, Write, Bash, Grep, Glob
+version: 1.0.0
+license: MIT
+metadata:
+  author: Foundation Skills
+---
+
+# Meeting Report
+
+Generate a structured French meeting report from a Microsoft Teams `.vtt` transcript, optionally enriched with a Teams `.csv` attendance report. The report is written to the correct sub-domain folder under `docs/reports/` inside the **hexagone-monorepo** project.
+
+**This skill is specific to the hexagone-monorepo project.** It assumes the working directory is hexagone-monorepo and that `docs/reports/` exists with the following sub-domain folders: `foundation/`, `core/`, `gap/`, `grh/`, `gef/`, `ui-ux/`.
+
+## When to Use This Skill
+
+Activate when the user:
+- Dépose un chemin vers un fichier `.vtt` Teams dans le prompt
+- Dit « crée un compte-rendu de cette transcription Teams »
+- Dit « génère le compte-rendu de cette réunion »
+- Dit « transforme cette transcription en rapport »
+- Dépose en plus un fichier `.csv` de présence Teams (optionnel)
+
+## Inputs
+
+The skill expects **one or two file paths** dropped in the user prompt:
+
+- **Required:** `.vtt` file — Teams meeting transcript in WebVTT format
+- **Optional:** `.csv` file — Teams attendance report
+
+Detection: inspect file extensions in the user prompt. If both are present, `.vtt` is the transcript and `.csv` is the attendance report. If only one file is dropped, it must be the `.vtt`.
+
+## Workflow
+
+### Step 1: Locate and Read the Files
+
+1. Parse the user prompt for file paths (look for `.vtt` and `.csv` extensions)
+2. Verify each file exists using Read
+3. If no `.vtt` is found → stop and ask the user to provide one
+4. Read the `.vtt` content entirely
+5. Read the `.csv` content if provided
+
+### Step 2: Parse the Transcript
+
+Teams `.vtt` file structure:
+
+```
+WEBVTT
+
+NOTE
+Meeting metadata may appear here (date, title, organizer)
+
+00:00:01.000 --> 00:00:04.000
+<v Speaker Name>Speech content</v>
+
+00:00:05.000 --> 00:00:08.000
+Anonymous speech without voice tag
+```
+
+Extract:
+
+1. **Meeting date** — try in this order:
+   - **(a)** `NOTE` header content containing a date pattern (ISO `YYYY-MM-DD` or French `DD/MM/YYYY`)
+   - **(b)** Filename date pattern (e.g. `20260410_...vtt` → `2026-04-10`)
+   - **(c)** Today's date as fallback
+2. **Speakers** — parse `<v Speaker Name>...</v>` voice tags (may be absent)
+3. **Content blocks** — each timestamped segment is a speaker turn
+
+### Step 3: Resolve Participants
+
+Priority order:
+
+1. **If `.csv` attendance report provided** → parse it and extract the `Name` column. Teams attendance CSVs typically contain columns like `Name`, `First Join`, `Last Leave`, `Duration`, `Role`, `Email`. Use names only for the `## Participants` section.
+2. **Else if `<v>` voice tags are present in the `.vtt`** → extract unique speaker names
+3. **Else** → **stop and ask the user** to provide the participants list before continuing:
+
+   > « La transcription est anonyme et aucun fichier de présence n'est fourni. Peux-tu me donner la liste des participants ? »
+
+### Step 4: Classify the Sub-Domain
+
+Analyze transcript content for domain signals using the table below (case-insensitive keyword matching):
+
+| Folder | Signals (French keywords) |
+|---|---|
+| `foundation/` | sprint, rétro, rétrospective, point équipe, stand-up, daily, foundation, équipe foundation |
+| `core/` | architecture transversale, cross-domain, LDAP, S3A, S3A settings, permissions utilisateur, rôles, authentification |
+| `gap/` | admission, patient, venue, séjour, dossier patient, pré-admission, AMO, AMC, débiteur, couverture sociale, facturation, valorisation, portail patient, ROC, serveur d'actes, actes, urgences, Diapason |
+| `grh/` | RH, ressources humaines, employé, salarié, contrat, paie, MyRHConnect, RH Dossier |
+| `gef/` | pharmacie, M21, contentieux, emprunts, trésorerie, HA GHT, immobilisations, achats, fournisseurs, comptabilité générale, Hélios, export comptable |
+| `ui-ux/` | design, maquette, Figma, atelier UX, atelier UI, wireframe, écran, prototype, UX/UI |
+
+**Classification rule:**
+
+1. If the meeting is clearly an internal **Foundation team recurring meeting** (sprint, rétro, daily, point équipe, stand-up) → `foundation/`
+2. Otherwise, count keyword matches per domain folder and pick the **folder with the highest count** (dominant domain)
+3. On a tie, prefer the folder whose signals appear earliest in the transcript
+4. If no signals match at all → ask the user to confirm the target folder
+
+### Step 5: Extract Meeting Title and Slug
+
+1. Read the first minutes of the transcript for explicit subject references (greetings usually mention the meeting title)
+2. Infer a clean French meeting title (e.g. `Atelier UX/UI Recherche Patient`)
+3. Generate a kebab-case slug from the title:
+   - Lowercase, ASCII only (strip accents)
+   - Replace spaces and punctuation with `-`
+   - Max ~60 characters
+   - Example: `atelier-ux-ui-recherche-patient`
+
+### Step 6: Rewrite Content by Topic
+
+**Style:** Heavy rewrite, grouped by topic, **not** chronological, **not** verbatim.
+
+1. Identify the main topics discussed — cluster speaker turns into thematic groups (topic detection, not speaker order)
+2. For each topic, extract:
+   - **Décisions** — concrete decisions made (always present as a `### Décisions` subsection)
+   - **Point d'attention** — ambiguities, unresolved items (optional `### Point d'attention` subsection)
+   - **Problèmes identifiés** — blockers, technical issues, missing dependencies (optional `### Problèmes identifiés` subsection)
+3. Write in professional French:
+   - Use "nous" or impersonal tone
+   - **Fix all missing accents aggressively** — Teams French transcripts are notoriously bad with accents and punctuation
+   - **Remove filler words** — « euh », « du coup », « en fait », repetitions, stammering
+   - Use `**bold**` emphasis on key terms inside decision bullets
+4. **Target length: 800–1500 words** for the full report
+5. Number the sections: `## 1. <Topic>`, `## 2. <Topic>`, etc.
+6. **Do not quote speakers verbatim.** The output is a synthesized report, not minutes.
+
+### Step 7: Extract Actions
+
+Comb the transcript for action items — things to do, follow-ups, commitments, decisions requiring later implementation. Identify for each:
+
+- **Action** — the thing to do
+- **Responsable** — who was assigned (or « À préciser » if unclear)
+- **Statut** — typical values: `À planifier`, `En cours`, `En attente`, `Terminé`
+
+Format as a Markdown table. The `## Actions` section is **always present** at the end of the report. If no actions were identified, write a single row:
+
+```markdown
+| Action | Responsable | Statut |
+|--------|-------------|--------|
+| Aucune action identifiée | — | — |
+```
+
+### Step 8: Decide Whether to Add a Mermaid Diagram
+
+Add a mermaid diagram **only** when the content genuinely benefits from visualization. Good triggers:
+
+- Multi-step workflows (e.g. a facturation 6/8/7-step process)
+- Decision trees with clear branches
+- Sequence of events between multiple actors (e.g. admission → séjour → facturation)
+- Data flow between systems
+
+Prefer these diagram types:
+- `flowchart LR` or `flowchart TD` for processes and decisions
+- `sequenceDiagram` for inter-actor interactions
+- `timeline` for project phases
+
+Place the diagram **inside the relevant topic section**, not at the top of the report.
+
+**Default: no diagram.** When in doubt, skip it. A report without a diagram is the norm, not the exception.
+
+### Step 9: Assemble the Report
+
+Use this exact template (matches the hexagone-monorepo existing convention):
+
+```markdown
+# Compte-rendu — <Type de réunion> <Sujet>
+
+**Date :** DD/MM/YYYY
+**Organisateur :** <Nom> (<Rôle>)
+
+## Participants
+
+<Nom1>, <Nom2>, <Nom3>, ...
+
+---
+
+## 1. <Topic 1>
+
+### Décisions
+
+- **<Key term>** : <decision>
+- ...
+
+### Point d'attention
+
+<Optional paragraph — only when there is an ambiguity or unresolved item>
+
+### Problèmes identifiés
+
+- <Optional bullet list — only when problems were raised>
+
+---
+
+## 2. <Topic 2>
+
+### Décisions
+
+- ...
+
+---
+
+<...as many topics as needed...>
+
+## Actions
+
+| Action | Responsable | Statut |
+|--------|-------------|--------|
+| ... | ... | ... |
+```
+
+**Rules:**
+- **No YAML front-matter**
+- **Date in French format** `DD/MM/YYYY` in the body (ISO only in the filename)
+- **Participants** is a single comma-separated line, not a table, no roles
+- **Organisateur**: if identifiable from transcript/csv, write `**Organisateur :** Nom (Rôle)`. If not identifiable, write `**Organisateur :** À préciser`
+- `---` horizontal rule separator between topics
+- `## Actions` always at the very end
+
+### Step 10: Determine the Filename
+
+Rule:
+
+- **Foundation team meetings** (`foundation/` folder) → `YYYY-MM-DD.md` (date only, no slug — one standing team meeting per day maximum)
+- **All other folders** → `YYYY-MM-DD-<slug>.md`
+
+The filename always uses the **ISO date format** `YYYY-MM-DD`, different from the French `DD/MM/YYYY` used in the report body.
+
+### Step 11: Write the File
+
+1. Build the target path: `docs/reports/<folder>/<filename>.md`
+2. Verify the target folder exists using Bash (`ls docs/reports/<folder>/`)
+3. Check if a file with the same name already exists — if yes, append `-2`, `-3`, etc. before writing (do NOT overwrite)
+4. Write the file with the Write tool
+
+### Step 12: Report to the User
+
+Show a concise summary:
+
+1. ✓ Target path: `docs/reports/<folder>/<filename>.md`
+2. One-line summary: domain detected, number of topics, number of actions, number of participants
+3. Note any fallback that was triggered (no attendance CSV, no voice tags, today's date used because no date found, etc.)
+4. **Stop.** Do not run `git add`, `git commit`, or `git push`. The user commits the file manually after review.
+
+## Important Notes
+
+- **This skill is specific to the hexagone-monorepo project.** It assumes the current working directory is hexagone-monorepo and that `docs/reports/<sub-domain>/` exists for the six domains.
+- **No redaction or pseudonymization.** Team meetings are considered internal and trusted. Patient names, client hospitals, commercial info, and personnel names may appear verbatim in reports.
+- **No git actions.** The skill writes the file and stops. Commit and push are manual.
+- **Rewrite heavily — do not transcribe.** The output is a thematic synthesis, not chronological minutes.
+- **Fix French accents aggressively.** Teams `.vtt` French transcripts routinely miss accents and punctuation.
+- **Foundation meetings use date-only naming.** All other folders use `YYYY-MM-DD-<slug>.md`.
+- **Mermaid is optional, rare, and only when useful.** Default is no diagram.
+- **Participants fallback order:** `.csv` first, then `<v>` voice tags, then ask the user. Never invent names.
+- **Never overwrite an existing report.** Append a numeric suffix if a file with the same name already exists.
+
+## Examples
+
+### Example 1: UX/UI atelier with attendance CSV
+
+```
+User: crée un compte-rendu de cette transcription Teams /tmp/atelier_recherche_patient.vtt /tmp/attendees.csv
+
+→ Skill reads both files
+→ Extracts date from .vtt NOTE header: 2026-03-18
+→ Participants from .csv: Chloé Julenon, Richard Gill, Adrien Marcos, Myriam Fatoux, Damien Battistella
+→ Detects ui-ux signals (atelier, écran, maquette, recherche patient)
+→ Classifies as ui-ux/
+→ Extracts topics, decisions, actions
+→ Writes docs/reports/ui-ux/2026-03-18-atelier-recherche-patient.md
+→ Reports path to user
+```
+
+### Example 2: Foundation team sprint review, no CSV
+
+```
+User: génère le compte-rendu de cette réunion /tmp/sprint_review.vtt
+
+→ Skill reads the .vtt
+→ Parses <v Speaker> voice tags → extracts 4 speakers
+→ Extracts date from NOTE header: 2026-04-10
+→ Detects foundation signals (sprint, rétro, point équipe)
+→ Classifies as foundation/
+→ Uses date-only naming
+→ Writes docs/reports/foundation/2026-04-10.md
+```
+
+### Example 3: Anonymous transcript with no CSV
+
+```
+User: transforme cette transcription en rapport /tmp/meeting.vtt
+
+→ Skill reads the .vtt
+→ No <v> tags found
+→ No .csv provided
+→ Stops and asks: « La transcription est anonyme et aucun fichier de présence n'est fourni. Peux-tu me donner la liste des participants ? »
+→ Waits for the user, then continues with the provided names
+```
+
+### Example 4: Multi-domain transcript
+
+```
+User: compte-rendu /tmp/point_facturation_ght.vtt
+
+→ Skill reads the .vtt
+→ Detects signals for both gap (facturation, venue, séjour) and gef (HA GHT, pharmacie mentioned in passing)
+→ gap has significantly more keyword hits → picks gap as dominant
+→ Classifies as gap/
+→ Writes docs/reports/gap/2026-04-08-point-facturation-ght.md
+```


### PR DESCRIPTION
## Résumé technique

### Contexte
Skill spécifique au projet hexagone-monorepo pour automatiser la rédaction des comptes-rendus de réunion à partir des transcriptions Teams (`.vtt`) exportées après chaque réunion. Objectif : éliminer la charge manuelle de réécriture et garantir un format cohérent avec les rapports existants dans `docs/reports/`.

### Approche retenue
- **Entrée** : un ou deux chemins déposés dans le prompt — `.vtt` (requis, transcription WebVTT) + `.csv` (optionnel, rapport de présence Teams)
- **Parsing** : extraction de la date depuis le header `NOTE` du `.vtt` (fallback nom de fichier puis date du jour), des locuteurs via les balises `<v Speaker>`, ou depuis le `.csv` si fourni
- **Classification de domaine** : keyword matching sur 6 dossiers (`foundation`, `core`, `gap`, `grh`, `gef`, `ui-ux`) avec règle « domaine dominant » en cas de multi-domaine et cas spécial pour les réunions récurrentes Foundation
- **Rewrite** : lourd, groupé par sujet (non chronologique), extraction des décisions, correction agressive des accents, suppression du filler
- **Sortie** : template Markdown identique aux rapports existants (sections numérotées, `### Décisions` + optionnels, table `## Actions` toujours présente)
- **Mermaid** : optionnel, uniquement quand le contenu le justifie (workflows multi-étapes, arbres de décision)
- **Nommage** : `foundation/YYYY-MM-DD.md` (date seule) vs `<domaine>/YYYY-MM-DD-<slug>.md`

### Changements implémentés
| Fichier | Modification | Justification technique |
|---------|-------------|------------------------|
| `skills/meeting-report/SKILL.md` | Nouveau skill v1.0.0 | Instructions complètes pour l'agent IA (12 étapes du workflow, règles de routing, template exact) |
| `docs/meeting-report.md` | Nouvelle doc PO-oriented | Guide d'utilisation français pour l'équipe |
| `README.md` | Ajout dans la section Collaboration | Index des skills |
| `docs/README.md` | Ajout dans Gestion de projet | Index de la documentation |

### Points d'attention pour la revue
- **Scope du skill** : explicitement limité à hexagone-monorepo (suppose `docs/reports/<domaine>/` existant). Pas pensé pour être universel.
- **Mots-clés de routing** : validés en direct avec l'équipe lors de la conception — à ajuster si de nouveaux termes/produits apparaissent (ex: Diapason, MyRHConnect, HA GHT)
- **Pas de redaction/PII** : assomption que les réunions internes sont sûres, pas de pseudonymisation des noms patients/clients
- **Aucune action Git** : le skill s'arrête après écriture du fichier, revue et commit manuels
- **Fallback participants** : arrêt et demande utilisateur si ni `.csv` ni balises `<v>` (jamais d'invention de noms)
- **Pas de front-matter YAML** dans les rapports générés — correspond au format existant

### Tests
- Pas de tests automatisés (skills basés sur Markdown, testés en conditions réelles)
- À valider : dépôt d'une transcription `.vtt` + `.csv` réelle dans une session hexagone-monorepo

### Prochaines étapes
- [ ] Revue du SKILL.md par l'équipe Foundation
- [ ] Test sur une vraie transcription Teams
- [ ] Ajustement des mots-clés de routing si besoin
- [ ] Merge après validation

---
_Implémentation générée automatiquement par IA_