### PR TITLE
feat(qa-skills): Add manual-test-designer and qa-automation skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,8 @@ graph LR
 |-------|-------------|-----|
 | **tdd** | Développement piloté par les tests (red-green-refactor) | [doc](docs/tdd.md) |
 | **testing-patterns** | Patterns de test : unitaire, intégration, E2E, mocking | [doc](docs/testing-patterns.md) |
+| **manual-test-designer** | Génération de cas de test manuels CSV (Xray) et JDD JSON depuis des user stories | [doc](docs/manual-test-designer.md) |
+| **qa-automation** | Automatisation Playwright/TypeScript avec architecture 3 couches (Spec → Steps → POM) | [doc](docs/qa-automation.md) |
 | **security-review** | Audit de sécurité et OWASP Top 10 | [doc](docs/security-review.md) |
 | **git-guardrails** | Bloque les commandes git dangereuses (push --force, reset --hard) | [doc](docs/git-guardrails.md) |
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -39,9 +39,11 @@ Index de la documentation disponible pour les Foundation Skills.
 
 ### Automatisation & Tests
 
-| Skill                                   | Documentation                             |
-| --------------------------------------- | ----------------------------------------- |
-| [playwright-skill](playwright-skill.md) | Automatisation navigateur avec Playwright |
+| Skill                                                         | Documentation                                                          |
+| ------------------------------------------------------------- | ---------------------------------------------------------------------- |
+| [playwright-skill](playwright-skill.md)                       | Automatisation navigateur avec Playwright                              |
+| [manual-test-designer](manual-test-designer.md)               | Génération de cas de test manuels CSV (Xray) et JDD JSON               |
+| [qa-automation](qa-automation.md)                             | Automatisation Playwright/TypeScript — architecture 3 couches (Spec → Steps → POM) |
 
 ### Documents Office
 

--- a/docs/manual-test-designer.md
+++ b/docs/manual-test-designer.md
@@ -1,0 +1,140 @@
+# manual-test-designer
+
+Génère des cas de test manuels structurés et prêts à importer dans **Xray** (format CSV), ainsi que des jeux de données de test (fichiers JDD JSON), à partir d'user stories, de descriptions de fonctionnalités ou de critères d'acceptation.
+
+## Pourquoi ce skill
+
+- **Gain de temps** — Transforme des user stories en jeux de tests complets en quelques minutes
+- **Qualité garantie** — Applique systématiquement les techniques de conception de tests (EP, BVA, Decision Tables, State Transition, Pairwise, Error Guessing)
+- **Zéro redondance** — Déduplique agressivement : un cas de test par classe d'équivalence, pas de variantes inutiles
+- **Prêt pour l'automation** — Les JDD générés sont directement réutilisables par le skill `qa-automation` pour scaffolder des tests Playwright
+
+## Quand utiliser ce skill
+
+- Rédiger les cas de test d'une nouvelle fonctionnalité avant le développement
+- Créer un fichier CSV à importer dans Xray/Jira
+- Générer des données de test structurées (fichiers JDD JSON)
+- Préparer les scénarios de recette fonctionnelle
+- Assurer la couverture des cas nominaux, limites, erreurs et règles métier
+
+## Workflow en 5 étapes
+
+| Étape | Action |
+|-------|--------|
+| 1. Analyser | Lire l'user story, identifier les exigences testables, les champs de saisie et les règles métier |
+| 2. Sélectionner | Choisir les techniques de conception selon le type d'entrées détectées |
+| 3. Concevoir | Générer les cas de test (nominal, limite, invalide, erreur, règle métier) sans doublons |
+| 4. Générer le CSV | Produire le fichier CSV en 9 colonnes, séparateur `;`, prêt pour Xray |
+| 5. Générer le JDD | (optionnel) Créer le fichier JSON `fixtures/jdd/` avec entrants et sortants |
+
+## Techniques de conception appliquées
+
+| Technique | Déclencheur |
+|-----------|-------------|
+| **Equivalence Partitioning (EP)** | Tout champ de saisie (texte, dropdown, toggle) |
+| **Boundary Value Analysis (BVA)** | Champs numériques, longueurs de chaînes, dates, listes |
+| **Decision Tables** | Combinaisons de conditions → résultats différents |
+| **State Transition** | Formulaires multi-étapes, changements de statut, workflows |
+| **Pairwise Testing** | 3+ paramètres indépendants avec plusieurs valeurs |
+| **Error Guessing** | Toujours — complète les techniques formelles |
+
+## Format de sortie
+
+### CSV Xray (9 colonnes)
+
+```
+Test ID;Summary;Description;Repository;Preconditions;Test Steps;Expected Results;Priority;Labels
+```
+
+| Colonne | Description |
+|---------|-------------|
+| `Test ID` | Laisser vide pour les nouveaux tests (Xray assigne la clé à l'import) |
+| `Summary` | Titre concis : `[Action principale] — [contexte/variante]` |
+| `Description` | Description fonctionnelle courte (1-3 phrases) |
+| `Repository` | Chemin hiérarchique : `Module/SousModule/Fonctionnalité/` |
+| `Preconditions` | Liste à puces (`- `) des pré-requis avant exécution |
+| `Test Steps` | Étapes numérotées avec verbe d'action et données concrètes |
+| `Expected Results` | Résultats numérotés, observables, spécifiques |
+| `Priority` | `High` (P0) / `Medium` (P1) / `Low` (P2) |
+| `Labels` | Tags CSV : `smoke,auth,positive` ou `regression,negative` |
+
+### Niveaux de priorité
+
+| Priorité | Usage |
+|----------|-------|
+| **P0 — High** | Chemin bloquant. Si ce test échoue, la fonctionnalité est inutilisable. Smoke tests, règles métier critiques. |
+| **P1 — Medium** | Fonctionnel cœur. Scénarios de régression, gestion des erreurs principales, validations clés. |
+| **P2 — Low** | Cas limites, validations cosmétiques, fonctionnalités de confort, exploration des frontières. |
+
+### JDD JSON (optionnel)
+
+Fichier structuré externalisant les données d'entrée (`entrants`) et les résultats attendus (`sortants`) :
+
+```json
+{
+  "metadata": {
+    "description": "Jeu de données pour les cas de test de la fonctionnalité X",
+    "version": "1.0.0",
+    "lastUpdated": "2026-04-23"
+  },
+  "entrants": {
+    "champLibelle": "Curry de poulet au lait de coco",
+    "famillePlat": "VVPO",
+    "destinations": ["CHBA", "CHU"]
+  },
+  "sortants": {
+    "texteFormCreation": "Création d'une fiche plat",
+    "messageErreurLibelleVide": "Le champ Libellé est obligatoire",
+    "texteBtnAjouter": "Ajouter un plat"
+  }
+}
+```
+
+## Paramètres par défaut (modifiables)
+
+| Paramètre | Valeur par défaut |
+|-----------|-------------------|
+| Langue du contenu | Français |
+| Séparateur CSV | `;` (point-virgule) |
+| Format ID de test | `TC-[MODULE]-[NNN]` |
+| Format nom de test | `TC_[PRODUIT]_[MODULE]_[FEATURE]_[ID]_[NOM]` |
+| Chemin JDD | `fixtures/jdd/[PRODUIT]-[MODULE]-[NNN].json` |
+
+## Contenu du skill
+
+| Fichier | Description |
+|---------|-------------|
+| `SKILL.md` | Instructions principales — workflow en 5 étapes |
+| `reference/csv-format-guide.md` | Spécification complète des 9 colonnes CSV + règles de rédaction |
+| `reference/test-design-techniques.md` | Quand et comment appliquer EP, BVA, Decision Tables, State Transition, Pairwise, Error Guessing |
+| `reference/jdd-generation.md` | Guide de génération des fichiers JDD JSON (entrants/sortants, nommage, mapping) |
+| `reference/examples.md` | Exemples complets de CSV et JDD pour différents types de fonctionnalités |
+
+## Intégration avec qa-automation
+
+Le CSV généré par ce skill (et les fichiers JDD JSON) servent de base d'entrée pour le skill **`qa-automation`** :
+
+```
+manual-test-designer  ──►  CSV Xray + JDD JSON  ──►  qa-automation
+   (conception manuelle)     (données structurées)     (automatisation Playwright)
+```
+
+Les fichiers JDD générés respectent exactement le format `entrants/sortants` attendu par l'architecture 3 couches du skill `qa-automation`.
+
+## Installation
+
+```bash
+npx skills add Dedalus-ERP-PAS/foundation-skills --skill manual-test-designer -g -y
+```
+
+## Utilisation
+
+Fournissez une user story, une description de fonctionnalité ou des critères d'acceptation :
+
+> « Génère les cas de test pour la fonctionnalité de création d'une fiche plat. Un plat a un libellé (obligatoire, max 100 chars), une famille (dropdown obligatoire), et une liste de destinations (multi-sélection, au moins une requise). »
+
+L'agent :
+1. Identifie les exigences testables et les règles de validation
+2. Applique EP, BVA et Decision Tables sur les champs concernés
+3. Génère un CSV à 9 colonnes prêt pour import Xray
+4. Propose optionnellement un fichier JDD JSON associé

--- a/docs/qa-automation.md
+++ b/docs/qa-automation.md
@@ -1,0 +1,223 @@
+# qa-automation
+
+Skill d'automatisation de tests **end-to-end** avec **Playwright** et **TypeScript**, basé sur une architecture 3 couches stricte (Spec → Steps → POM) avec injection de dépendances par fixtures et données de test externalisées (JDD entrants/sortants).
+
+## Pourquoi ce skill
+
+- **Architecture disciplinée** — Séparation stricte des responsabilités : aucun locator dans les specs, aucune logique métier dans les POM
+- **Maintenabilité maximale** — Les données de test sont externalisées dans des fichiers JSON typés ; aucune chaîne de caractères codée en dur dans les tests
+- **Traçabilité Xray** — Chaque test porte ses annotations `test_key` et `test_summary` pour la remontée automatique dans Jira/Xray
+- **Intégration continue** — Configuration CI/CD ready avec tags (`@smoke`, `@regression`, `@wip`) et rapports Allure + JUnit
+
+## Quand utiliser ce skill
+
+- Créer un nouveau test automatisé pour une fonctionnalité
+- Ajouter un Page Object Model (POM) pour une nouvelle page ou composant
+- Écrire des Steps encapsulant la logique métier d'un flux
+- Câbler les fixtures d'injection de dépendances pour un nouveau module
+- Créer ou modifier des jeux de données de test (JDD JSON)
+- Déboguer un test qui échoue ou qui est instable (flaky)
+- Mettre en place la stratégie de tags pour CI/CD
+
+## Architecture 3 couches
+
+```
+tests/**/*.spec.ts          ← Couche 1 : Specs (orchestration UNIQUEMENT)
+    ↓ importe fixture
+src/utils/fixtures/*.ts     ← Injection de dépendances (câblage UNIQUEMENT)
+    ↓ injecte
+src/steps/**/*.ts           ← Couche 2 : Steps (logique métier, PAS de locators)
+    ↓ appelle méthodes de
+src/pages/**/*.ts           ← Couche 3 : POM (locators + interactions UI UNIQUEMENT)
+    ↑ lit
+fixtures/jdd/*.json         ← Données de test : entrants (inputs) / sortants (attendus)
+```
+
+### Règles d'or
+
+| Règle | Description |
+|-------|-------------|
+| **Instanciation** | `new PageX()` et `new StepsX()` — UNIQUEMENT dans les fichiers fixture |
+| **Locators** | UNIQUEMENT dans le POM (Couche 3), jamais dans specs ni steps |
+| **Logique métier** | UNIQUEMENT dans les Steps (Couche 2), jamais dans les specs |
+| **Specs** | Orchestration uniquement — appel de méthodes steps, pas d'interaction page directe |
+| **JDD** | Externaliser TOUTES les données de test ; aucune chaîne codée en dur |
+| **Typage** | Interfaces TypeScript pour les JDD, jamais `any` |
+
+## Workflow en 6 étapes
+
+| Étape | Action |
+|-------|--------|
+| 1. Découvrir | Explorer le codebase : fixtures, steps, pages, enums, types, `conf.json` |
+| 2. Identifier la couche | Déterminer quel fichier créer/modifier selon la tâche |
+| 3. Implémenter | Suivre les règles strictes de la couche concernée |
+| 4. Câbler les fixtures | Enregistrer les nouvelles pages/steps dans le fichier fixture du module |
+| 5. Écrire le spec | Orchestrer avec tags Xray, annotations et import JDD |
+| 6. Vérifier | Exécuter `npx playwright test`, contrôler le rapport Allure, valider les assertions |
+
+## Correspondance tâche ↔ couche
+
+| Tâche | Couche | Pattern de fichier |
+|-------|--------|--------------------|
+| Nouvelle interaction UI | POM | `src/pages/[module]/PageFeature.ts` |
+| Nouveau flux métier | Steps | `src/steps/[module]/EtapesFeature.ts` |
+| Nouveau scénario de test | Spec | `tests/[module]/feature.spec.ts` |
+| Nouvelles données de test | JDD | `fixtures/jdd/[PRODUIT]-[MODULE]-[NNN].json` |
+| Câblage d'un nouveau module | Fixture | `src/utils/fixtures/[module].fixtures.ts` |
+
+## Exemples de code
+
+### Spec (Couche 1) — Orchestration uniquement
+
+```typescript
+import { test } from "../../src/utils/fixtures/module.fixtures";
+import * as jdd from "../../fixtures/jdd/PRODUCT-MODULE-001.json";
+
+test.describe("Fiches plat — Création", { tag: ["@regression", "@fichesPlatModule"] }, () => {
+  test(
+    "ERPPASTEST-001 TC_SRD_FP_Creation_libelle_nominal",
+    {
+      tag: "@ERPPASTEST-001",
+      annotation: [
+        { type: "test_key", description: "ERPPASTEST-001" },
+        { type: "test_summary", description: "TC_SRD_FP_Creation_libelle_nominal" },
+      ],
+    },
+    async ({ etapesFichesPlatCreation }) => {
+      await etapesFichesPlatCreation.navigateToFichesPlat();
+      await etapesFichesPlatCreation.creerFicheNewPlat(jdd.entrants, jdd.sortants);
+    }
+  );
+});
+```
+
+### Steps (Couche 2) — Logique métier, pas de locators
+
+```typescript
+export class EtapesFichesPlatCreation {
+  constructor(
+    private readonly navigation: Navigation,
+    private readonly pageFichesPlatCreation: PageFichesPlatCreation
+  ) {}
+
+  async creerFicheNewPlat(entrants: FPEntrants, sortants: FPSortants): Promise<void> {
+    logger.step(`Création fiche plat : "${entrants.volet1.libelle}"`);
+    await this.pageFichesPlatCreation.ouvrirFormulaireCreation(sortants.texteBtnAjoutPlat);
+    await this.pageFichesPlatCreation.remplirVolet1(entrants.volet1);
+    await this.pageFichesPlatCreation.remplirVolet2(entrants.volet2);
+    await this.pageFichesPlatCreation.valider();
+    await this.pageFichesPlatCreation.verifierCreation(sortants);
+    logger.success(`Fiche plat créée : "${entrants.volet1.libelle}"`);
+  }
+}
+```
+
+### JDD JSON — Données externalisées (entrants/sortants)
+
+```json
+{
+  "metadata": {
+    "description": "Création d'une fiche plat nominale — volets 1 et 2",
+    "version": "1.0.0",
+    "lastUpdated": "2026-04-23"
+  },
+  "entrants": {
+    "volet1": {
+      "libelle": "Curry de poulet au lait de coco",
+      "famillePlat": "VVPO",
+      "sousFamille": "Viande - volaille"
+    },
+    "volet2": {
+      "destinations": ["CHBA", "CHU", "Cité ADM"]
+    }
+  },
+  "sortants": {
+    "texteBtnAjoutPlat": "Ajouter un plat",
+    "texteFormCreationFP": "Création d'une fiche plat",
+    "messageFicheCreee": "Fiche plat créée avec succès"
+  }
+}
+```
+
+## Stratégie de locators
+
+| Priorité | Méthode | Exemple |
+|----------|---------|---------|
+| 1 (préféré) | `getByRole` | `page.getByRole('button', { name: 'Valider' })` |
+| 2 | `getByLabel` | `page.getByLabel('Libellé')` |
+| 3 | `getByTestId` | `page.getByTestId('submit-btn')` |
+| 4 (dernier recours) | CSS sémantique | `page.locator('[data-module="fiches-plat"]')` |
+| À éviter | CSS fragile | `page.locator('.btn-primary:nth-child(3)')` |
+
+## Stratégie de tags
+
+| Tag | Usage | Quand exécuté |
+|-----|-------|---------------|
+| `@smoke` | Chemin critique, must-pass | Chaque pipeline |
+| `@regression` | Couverture régression complète | Nuit / release |
+| `@moduleName` | Regroupement par module | Exécutions ciblées |
+| `@XRAY-KEY-NNN` | Traçabilité Xray | Test individuel |
+| `@wip` | Travail en cours | Exclu du CI |
+
+```bash
+# Exécution par tag
+npx playwright test --grep @smoke
+npx playwright test --grep @regression
+npx playwright test --grep @ERPPASTEST-001
+```
+
+## Checklist nouveau test
+
+```
+[ ] 1. Créer le JDD            fixtures/jdd/[PRODUIT]-[MODULE]-NNN.json
+[ ] 2. Créer les types TS      src/types/[feature].types.ts (interfaces entrants/sortants)
+[ ] 3. Créer le POM            src/pages/[module]/PageFeature.ts (extends BasePage)
+[ ] 4. Exporter depuis index   src/pages/[module]/index.ts
+[ ] 5. Créer les Steps         src/steps/[module]/[feature]/EtapesFeature.ts
+[ ] 6. Exporter depuis index   src/steps/index.ts
+[ ] 7. Créer/màj la fixture    src/utils/fixtures/[module].fixtures.ts
+[ ] 8. Exporter depuis index   src/utils/fixtures/index.ts
+[ ] 9. Créer le spec           tests/[module]/feature.spec.ts
+[ ] 10. Exécuter et vérifier   npx playwright test tests/[module]/feature.spec.ts
+```
+
+## Contenu du skill
+
+| Fichier | Description |
+|---------|-------------|
+| `SKILL.md` | Instructions principales — workflow et règles d'or |
+| `reference/architecture.md` | Guide complet des 3 couches, fixtures, configuration d'environnement |
+| `reference/patterns.md` | Patterns réutilisables : wizard multi-étapes, search & select, filtres, CRUD |
+| `reference/locator-strategy.md` | Stratégie accessibilité-first, locators personnalisés, attentes et stabilité |
+| `reference/test-data.md` | Structure JDD : entrants/sortants, typage, nommage, nettoyage |
+| `reference/checklist.md` | Checklist nouvelle feature, stratégie de tags, débogage, CI/CD |
+
+## Intégration avec manual-test-designer
+
+Le skill **`manual-test-designer`** génère des cas de test manuels (CSV Xray) et des fichiers JDD JSON. Ces fichiers servent de base d'entrée pour `qa-automation` :
+
+```
+manual-test-designer  ──►  CSV Xray + JDD JSON  ──►  qa-automation
+   (conception manuelle)     (données structurées)     (automatisation Playwright)
+```
+
+Les fichiers JDD produits par `manual-test-designer` respectent exactement le format `entrants/sortants` consommé par ce skill.
+
+## Installation
+
+```bash
+npx skills add Dedalus-ERP-PAS/foundation-skills --skill qa-automation -g -y
+```
+
+## Utilisation
+
+Demandez à votre agent IA d'automatiser un scénario de test :
+
+> « Crée un test Playwright pour la création d'une fiche plat. Utilise le JDD `fixtures/jdd/SRD-FP-001.json` et suit l'architecture 3 couches du projet. »
+
+L'agent :
+1. Explore le codebase pour comprendre les fixtures, steps et pages existants
+2. Identifie les couches à créer ou modifier
+3. Génère le POM, les Steps, la fixture et le spec en respectant les règles d'or
+4. Câble l'injection de dépendances
+5. Fournit la commande d'exécution et les tags appropriés

--- a/skills/manual-test-designer/SKILL.md
+++ b/skills/manual-test-designer/SKILL.md
@@ -1,0 +1,75 @@
+---
+name: manual-test-designer
+description: "Generate Xray-compatible manual test cases (CSV) and optional JDD test data (JSON) from user stories, feature descriptions, or acceptance criteria. Use when the user wants to create manual test cases, generate test scenarios, design functional tests, produce Xray CSV imports, or create JDD test data files."
+version: 1.0.0
+---
+
+# Manual Test Designer
+
+Generate structured, non-redundant manual test cases ready for Xray import, with optional JDD test data.
+
+## Workflow
+
+### Step 1 — Analyze Input
+
+Read the user story, feature description, or acceptance criteria. Identify:
+- Testable requirements and acceptance criteria
+- Input fields, workflows, business rules
+- Risk areas (data integrity, security, UX)
+- Ambiguities to flag
+
+### Step 2 — Select Techniques
+
+Apply techniques based on what the input contains. See [test design techniques](reference/test-design-techniques.md).
+
+| Input characteristic | Technique |
+|---|---|
+| Any input field | Equivalence Partitioning |
+| Numeric/date/length fields | Boundary Value Analysis |
+| Multiple conditions combined | Decision Tables |
+| Multi-step workflow or statuses | State Transition |
+| 3+ independent parameters | Pairwise Testing |
+| Past defects, common failures | Error Guessing |
+
+### Step 3 — Design Test Cases
+
+For each requirement, generate test cases covering: **nominal**, **boundary**, **invalid input**, **error handling**, and **business rules**. Deduplicate aggressively — quality over quantity.
+
+### Step 4 — Generate CSV
+
+Output a semicolon-separated CSV table. See [CSV format guide](reference/csv-format-guide.md) and [examples](reference/examples.md).
+
+**Columns** (9): `Test ID;Summary;Description;Repository;Preconditions;Test Steps;Expected Results;Priority;Labels`
+
+### Step 5 — Generate JDD (optional)
+
+When test data is complex or the user requests it, generate a JDD JSON file. See [JDD generation guide](reference/jdd-generation.md).
+
+## Defaults (overridable)
+
+| Setting | Default |
+|---|---|
+| Language | French |
+| CSV separator | `;` (semicolon) |
+| Test ID format | `TC-[MODULE]-[NNN]` |
+| Test name format | `TC_[PRODUCT]_[MODULE]_[FEATURE]_[ID]_[NAME]` |
+| Priority levels | P0 = blocker/smoke, P1 = functional/regression, P2 = comfort/edge |
+| Repository path | `[Module]/[SousModule]/[Fonctionnalité]/` |
+
+## Priority Definitions
+
+- **P0** — Blocking path. If this fails, the feature is unusable. Smoke tests, critical business rules.
+- **P1** — Core functional. Regression-worthy scenarios, main error handling, key validations.
+- **P2** — Edge cases, cosmetic validations, comfort features, boundary exploration.
+
+## Constraints
+
+- ALL test content in **French**
+- No duplicate test cases — merge overlapping scenarios
+- No vague steps — every step has a concrete action and observable expected result
+- Use realistic test data (domain-appropriate values, not "test123")
+- Each test traces to a requirement or acceptance criterion
+
+## Integration
+
+The CSV output can feed into the `qa-automation` skill to scaffold automated Playwright tests.

--- a/skills/manual-test-designer/docs/manual-test-designer.md
+++ b/skills/manual-test-designer/docs/manual-test-designer.md
@@ -1,0 +1,88 @@
+# Manual Test Designer
+
+## Description
+
+Skill de génération de cas de test manuels à partir de user stories, descriptions fonctionnelles ou critères d'acceptation. Produit un fichier CSV compatible Xray (Jira) et optionnellement un fichier JDD (Jeux De Données) au format JSON.
+
+Le skill applique systématiquement les techniques de conception de tests ISTQB (Partitionnement en classes d'équivalence, Analyse des valeurs limites, Tables de décision, Transition d'états, Tests par paires) pour garantir une couverture optimale sans redondance.
+
+## Cas d'usage
+
+- Générer des cas de test manuels à partir d'une user story
+- Créer un fichier CSV importable dans Xray
+- Produire des jeux de données de test (JDD) structurés en JSON
+- Concevoir des tests couvrant les cas nominaux, limites, invalides et d'erreur
+- Prioriser les tests selon une analyse de risque (P0/P1/P2)
+
+## Déclenchement
+
+Le skill s'active quand l'utilisateur :
+- Demande de « créer des cas de test » ou « générer des tests »
+- Mentionne « Xray », « CSV », « import de tests »
+- Veut des « scénarios de test » pour une fonctionnalité
+- Demande un « jeu de données » ou « JDD » pour des tests
+- Parle de « conception de tests » ou « test design »
+
+## Fonctionnement
+
+### Étape 1 — Analyse de l'entrée
+Le skill analyse la user story ou la description fonctionnelle pour identifier les exigences testables, les champs d'entrée, les workflows et les règles métier.
+
+### Étape 2 — Sélection des techniques
+En fonction du contenu analysé, les techniques de test appropriées sont sélectionnées automatiquement (EP, BVA, Tables de décision, Transition d'états, Pairwise, Error Guessing).
+
+### Étape 3 — Conception des cas de test
+Les cas de test sont générés en couvrant : cas nominaux, valeurs limites, entrées invalides, gestion des erreurs et règles métier. Les doublons sont éliminés.
+
+### Étape 4 — Génération du CSV
+Un tableau CSV séparé par des points-virgules (`;`) est produit avec 9 colonnes : Test ID, Summary, Description, Repository, Preconditions, Test Steps, Expected Results, Priority, Labels.
+
+### Étape 5 — Génération du JDD (optionnel)
+Un fichier JSON structuré avec `metadata`, `entrants` (données d'entrée) et `sortants` (résultats attendus) est généré quand les données de test sont complexes.
+
+## Configuration par défaut
+
+| Paramètre | Valeur |
+|---|---|
+| Langue | Français |
+| Séparateur CSV | `;` (point-virgule) |
+| Niveaux de priorité | P0 (bloquant), P1 (fonctionnel), P2 (confort) |
+| Format ID test | `TC-[MODULE]-[NNN]` |
+| Chemin dépôt | `[Module]/[SousModule]/[Fonctionnalité]/` |
+
+Tous les paramètres sont modifiables via instruction en langage naturel.
+
+## Exemples
+
+### Entrée (user story en français)
+> En tant qu'utilisateur SRD, je veux me connecter à l'application afin d'accéder à mes fonctionnalités.
+
+### Sortie (extrait CSV)
+```csv
+Test ID;Summary;Description;Repository;Preconditions;Test Steps;Expected Results;Priority;Labels
+;Connexion réussie avec identifiants valides;Vérifier la connexion avec des identifiants corrects;Auth/Connexion/;"- Application accessible
+- Utilisateur valide existant";"1. Ouvrir l'URL
+2. Saisir identifiant et mot de passe
+3. Cliquer sur Connexion";"1. Page de connexion affichée
+2. Champs acceptent la saisie
+3. Redirection vers la page d'accueil";High;smoke,auth,positive
+```
+
+### Sortie (extrait JDD)
+```json
+{
+  "metadata": { "description": "JDD Auth", "version": "1.0.0" },
+  "entrants": { "identifiant": "adminsrd", "motDePasse": "***" },
+  "sortants": { "titrePageAccueil": "Accueil", "messageChargement": "Chargement du module en cours..." }
+}
+```
+
+## Intégration
+
+- Le CSV produit est compatible avec l'import Xray pour Jira
+- Le JDD JSON suit la convention `fixtures/jdd/SRD-[MODULE]-[NNN].json` du projet
+- Les cas de test générés peuvent alimenter le skill `qa-automation` pour le scaffolding de tests automatisés Playwright
+
+## Version
+
+1.0.0

--- a/skills/manual-test-designer/reference/csv-format-guide.md
+++ b/skills/manual-test-designer/reference/csv-format-guide.md
@@ -1,0 +1,143 @@
+# CSV Format Guide — Xray Import
+
+## Column Specification
+
+The CSV uses **semicolon (`;`)** as separator for French locale compatibility with Excel.
+
+**9 columns, in this exact order**:
+
+| # | Column | Xray field | Description |
+|---|---|---|---|
+| 1 | Test ID | Test Key | Leave empty for new tests. Xray assigns keys on import (e.g., `ERPPASTEST-NNN`). For updates, provide existing key. |
+| 2 | Summary | Summary | Concise title in French. Format: `[Action principale] — [contexte/variante]`. Max ~120 chars. |
+| 3 | Description | Description | Brief functional description (1-3 sentences). What this test validates and why. |
+| 4 | Repository | Test Repository Path | Hierarchical path using `/`. Example: `Auth/Connexion/`, `Paramétrage/Fiches plat/Création/` |
+| 5 | Preconditions | Precondition | Bulleted list using `- `. State required BEFORE the test starts. |
+| 6 | Test Steps | Test Steps | Numbered steps: `1. Action\n2. Action`. Each step = one user action. |
+| 7 | Expected Results | Expected Result | Numbered results matching steps: `1. Result\n2. Result`. Observable, verifiable. |
+| 8 | Priority | Priority | `High` (P0), `Medium` (P1), or `Low` (P2) |
+| 9 | Labels | Labels | Comma-separated tags: `smoke,auth,positive` or `regression,negative,validation` |
+
+## CSV Header Row
+
+```csv
+Test ID;Summary;Description;Repository;Preconditions;Test Steps;Expected Results;Priority;Labels
+```
+
+## Step Writing Rules
+
+### DO
+
+```
+1. Ouvrir l'URL de l'application SRD
+2. Saisir l'identifiant "admin" dans le champ Identifiant
+3. Saisir le mot de passe dans le champ Mot de passe
+4. Cliquer sur le bouton "Connexion"
+```
+
+- Start each step with an **action verb**: Ouvrir, Saisir, Cliquer, Vérifier, Sélectionner, Naviguer
+- Include **concrete data** inline: `"admin"`, `"VVPO"`, `"CHBA"`
+- One action per step — never combine two actions
+
+### DON'T
+
+```
+❌ "Remplir le formulaire" (too vague — which fields?)
+❌ "Se connecter à l'application" (what steps exactly?)
+❌ "Vérifier que tout fonctionne" (what specifically?)
+❌ "L'utilisateur fait des trucs" (non-actionable)
+```
+
+## Expected Result Writing Rules
+
+### DO
+
+```
+1. La page de connexion affiche le logo SRD et le formulaire
+2. Le champ accepte la saisie
+3. Le champ mot de passe masque les caractères (●●●)
+4. L'utilisateur est redirigé vers la page d'accueil
+```
+
+- Each result is **observable** — what the user sees or can verify
+- Match the numbering to the corresponding step
+- Be specific: mention exact UI elements, messages, behaviors
+
+### DON'T
+
+```
+❌ "Le système fonctionne correctement" (how do you verify?)
+❌ "Pas d'erreur" (what should happen instead?)
+❌ "OK" (not a result)
+```
+
+## Preconditions Format
+
+```
+- Application SRD accessible sur l'environnement de test
+- Utilisateur "adminsrd" existant avec droits Paramétrage
+- Navigateur Chrome/Firefox ouvert
+- Aucune fiche plat avec le libellé "Curry de poulet" existante
+```
+
+- Use `- ` bullet prefix
+- State the system's required state, not actions to perform
+- Include test data prerequisites (existing records, clean state)
+
+## Repository Path Convention
+
+The repository path creates the folder hierarchy in Xray.
+
+```
+[Module]/[SousModule]/[Fonctionnalité]/
+```
+
+**Examples**:
+
+| Feature | Repository path |
+|---|---|
+| Login | `Auth/Connexion/` |
+| Logout | `Auth/Déconnexion/` |
+| Module navigation | `Navigation/Modules/[Module]/` |
+| Sidebar | `Navigation/Sidebar/` |
+| Dish creation | `Paramétrage/Fiches plat/Création/` |
+| Dish modification | `Paramétrage/Fiches plat/Modification/` |
+
+## Labels Convention
+
+Use lowercase, no spaces. Combine as needed.
+
+| Category | Labels |
+|---|---|
+| Test type | `smoke`, `regression`, `functional`, `exploratory` |
+| Scenario polarity | `positive`, `negative` |
+| Concern | `validation`, `security`, `accessibility`, `performance` |
+| Module | `auth`, `navigation`, `parametrage`, `consommateur`, `collective` |
+| Special | `boundary`, `error-handling`, `business-rule`, `data-integrity` |
+
+## Priority Mapping
+
+| CSV value | Xray Priority | Skill level | Meaning |
+|---|---|---|---|
+| `High` | Highest/High | P0 | Blocking path — feature unusable if this fails |
+| `Medium` | Medium | P1 | Core functional — regression-worthy |
+| `Low` | Low | P2 | Edge case, comfort, boundary exploration |
+
+## Multi-line Content in CSV
+
+When steps or preconditions contain multiple lines, wrap the cell content in **double quotes** and use `\n` (literal newline) inside:
+
+```csv
+TC-AUTH-001;"Connexion réussie avec identifiants valides";"Vérifier qu'un utilisateur peut se connecter";"Auth/Connexion/";"- Application accessible\n- Utilisateur valide existant";"1. Ouvrir l'URL\n2. Saisir identifiant\n3. Cliquer Connexion";"1. Page de connexion affichée\n2. Champ accepte la saisie\n3. Redirection vers accueil";High;smoke,auth,positive
+```
+
+## Anti-patterns to Avoid
+
+| Anti-pattern | Problem | Fix |
+|---|---|---|
+| Duplicate tests | Same scenario tested with trivially different data | Merge into one test, mention data variations in description |
+| Missing preconditions | Test fails because required state was not set up | Always specify auth state, data prerequisites, UI state |
+| Vague expected results | "Should work correctly" — untestable | Specify exactly what the tester should see/verify |
+| Too many steps | 15+ steps in one test case | Split into smaller, focused test cases |
+| Technical jargon | "Verify the DOM contains element .btn-fab" | Use user-visible language: "Le bouton 'Ajouter un plat' est visible" |
+| Test data as "test123" | Unrealistic, doesn't catch real-world issues | Use domain-appropriate data: "Curry de poulet au lait de coco" |

--- a/skills/manual-test-designer/reference/examples.md
+++ b/skills/manual-test-designer/reference/examples.md
@@ -1,0 +1,244 @@
+# Examples — Input → Output
+
+Three real-world examples showing user story input and the generated CSV + JDD output.
+
+---
+
+## Example 1: Authentication (Simple — Login/Logout)
+
+### Input (User Story excerpt)
+
+> En tant qu'utilisateur SRD, je veux me connecter et me déconnecter de l'application afin d'accéder de manière sécurisée à mes fonctionnalités.
+>
+> **AC1**: Connexion avec identifiants valides → redirection vers page d'accueil
+> **AC2**: Connexion avec identifiant invalide → message d'erreur
+> **AC3**: Connexion avec mot de passe invalide → message d'erreur
+> **AC4**: Connexion avec champs vides → validation
+> **AC5**: Déconnexion → retour à la page de connexion
+
+### Techniques Applied
+
+- **EP**: Valid/invalid/empty credentials
+- **Decision Table**: username × password combinations
+- **Error Guessing**: "Se souvenir de moi", session timeout
+
+### Generated CSV Output
+
+```csv
+Test ID;Summary;Description;Repository;Preconditions;Test Steps;Expected Results;Priority;Labels
+;Connexion réussie avec identifiants valides;Vérifier qu'un utilisateur peut se connecter avec des identifiants valides;Auth/Connexion/;"- Application SRD accessible
+- Utilisateur valide (admin/mdp) existant
+- Navigateur ouvert";"1. Ouvrir l'URL de l'application SRD
+2. Vérifier que la page de connexion s'affiche
+3. Saisir l'identifiant ""admin"" dans le champ Identifiant
+4. Saisir le mot de passe ""mdp"" dans le champ Mot de passe
+5. Cliquer sur le bouton ""Connexion""";"1. La page de connexion affiche le logo SRD et le formulaire de connexion
+2. Le titre de la page contient ""SRD""
+3. Le champ accepte la saisie
+4. Le champ mot de passe masque les caractères
+5. L'utilisateur est redirigé vers la page d'accueil, le message ""Chargement du module en cours..."" puis ""Chargement des données en mémoire"" s'affichent";High;smoke,auth,positive
+;Connexion échouée avec identifiant invalide;Vérifier le comportement avec un identifiant inexistant;Auth/Connexion/;"- Application SRD accessible
+- Navigateur ouvert";"1. Ouvrir l'URL de l'application SRD
+2. Saisir un identifiant invalide ""utilisateur_inconnu""
+3. Saisir un mot de passe valide
+4. Cliquer sur le bouton ""Connexion""";"1. La page de connexion s'affiche
+2. Le champ accepte la saisie
+3. Le champ accepte la saisie
+4. Un message d'erreur s'affiche indiquant des identifiants incorrects";High;auth,negative,security
+;Connexion avec champs vides;Vérifier la validation lorsque les champs sont vides;Auth/Connexion/;"- Application SRD accessible
+- Navigateur ouvert";"1. Ouvrir l'URL de l'application SRD
+2. Laisser les champs Identifiant et Mot de passe vides
+3. Cliquer sur le bouton ""Connexion""";"1. La page de connexion s'affiche
+2. Les champs restent vides
+3. Un message de validation s'affiche pour les champs obligatoires";Medium;auth,negative,validation
+;Déconnexion réussie;Vérifier qu'un utilisateur connecté peut se déconnecter;Auth/Déconnexion/;"- Utilisateur connecté à l'application SRD";"1. Cliquer sur l'icône du Compte utilisateur (barre de navigation)
+2. Vérifier que le panneau utilisateur s'affiche
+3. Cliquer sur le bouton ""Se déconnecter""";"1. Le panneau affiche les informations utilisateur (groupe, profil)
+2. Le bouton ""Se déconnecter"" est visible
+3. L'utilisateur est déconnecté et redirigé vers la page de connexion";High;smoke,auth,positive
+```
+
+**Techniques visible**: EP (valid/invalid/empty = 3 classes), Decision Table (username × password reduced to meaningful rows), Error Guessing (empty fields).
+
+---
+
+## Example 2: Navigation (Parameterized — Multiple Modules)
+
+### Input (User Story excerpt)
+
+> En tant qu'utilisateur SRD, je veux accéder à tous les modules de l'application via le panneau Applications et naviguer dans les sous-menus via la sidebar.
+>
+> **Modules**: Consommateur, Collective, Exploitation, Paramétrage, Administration, Stock & achat, Production, Statistiques, Interop
+>
+> **AC1**: Ouvrir le panneau Applications et voir tous les modules
+> **AC2**: Naviguer vers chaque module
+> **AC3**: Sidebar expansion/réduction
+
+### Techniques Applied
+
+- **EP**: One test per module (each module = equivalence class for navigation)
+- **State Transition**: Sidebar collapsed ↔ expanded
+- **Error Guessing**: Fast module switching, sidebar animation timing
+
+### Generated CSV Output
+
+```csv
+Test ID;Summary;Description;Repository;Preconditions;Test Steps;Expected Results;Priority;Labels
+;Accès au panneau des Applications;Vérifier l'ouverture du panneau présentant tous les modules;Navigation/Panneau Applications/;"- Utilisateur connecté à l'application SRD";"1. Localiser l'icône Applications dans la barre de navigation horizontale
+2. Cliquer sur l'icône Applications";"1. L'icône Applications est visible dans la barre
+2. Un panneau s'ouvre présentant les 9 modules : Consommateur, Collective, Exploitation, Paramétrage, Administration, Stock & achat, Production, Statistiques, Interop. Chaque module est cliquable";High;smoke,navigation
+;Navigation vers module Consommateur;Vérifier l'accès au module Consommateur depuis le panneau Applications;Navigation/Modules/Consommateur/;"- Utilisateur connecté
+- Panneau Applications accessible";"1. Ouvrir le panneau Applications
+2. Cliquer sur le module ""Consommateur""";"1. Le panneau affiche tous les modules
+2. Le module Consommateur se charge, la sidebar affiche les sous-menus correspondants";High;smoke,navigation,consommateur
+;Expansion de la sidebar;Vérifier que la sidebar peut être étendue depuis le mode minifié;Navigation/Sidebar/;"- Utilisateur connecté
+- Sidebar en mode minifié (icônes uniquement)";"1. Observer la sidebar à gauche (mode minifié par défaut)
+2. Cliquer sur le bouton d'expansion de la sidebar
+3. Vérifier que les libellés des sous-menus apparaissent";"1. La sidebar affiche uniquement des icônes
+2. La sidebar s'étend avec une animation fluide
+3. Les libellés textuels des sous-menus sont visibles à côté des icônes";High;smoke,navigation
+;Réduction de la sidebar;Vérifier que la sidebar peut être réduite vers le mode minifié;Navigation/Sidebar/;"- Utilisateur connecté
+- Sidebar en mode étendu";"1. Vérifier que la sidebar est en mode étendu
+2. Cliquer sur le bouton de réduction
+3. Vérifier que seules les icônes sont visibles";"1. La sidebar affiche les libellés et icônes
+2. La sidebar se réduit avec une animation fluide
+3. Seules les icônes sont visibles, les libellés sont masqués";Medium;navigation,functional
+```
+
+**Note**: The remaining 8 module navigation tests (Collective through Interop) follow the same pattern as "Navigation vers module Consommateur" — in practice, use parameterized tests in automation rather than 9 separate CSV rows.
+
+---
+
+## Example 3: Multi-Volet Form (Complex — Dish Creation)
+
+### Input (User Story excerpt)
+
+> En tant que gestionnaire de la restauration, je veux créer une nouvelle fiche plat dans le module Paramétrage afin de référencer un plat.
+>
+> **Navigation**: Paramétrage → Fiches plat (contexte : Plat)
+>
+> **AC1**: Accès au formulaire de création via bouton FAB
+> **AC2**: Volet 1 — Informations générales (Libellé, Famille, Sous-famille, Poste, Groupe modes préparation)
+> **AC3**: Volet 2 — Destinations (multi-select avec "Sélectionner tout")
+> **AC4**: Volet 3 — Régimes et Rations
+> **AC5**: Volet 4 — Goûts + Validation finale
+> **AC6**: Gestion des erreurs et navigation entre volets
+
+### Techniques Applied
+
+- **State Transition**: 4-volet wizard flow (V1 → V2 → V3 → V4 → Saved, back navigation)
+- **EP**: Valid/empty/invalid for each field type
+- **BVA**: Multi-select boundaries (0, 1, all)
+- **Decision Table**: Required fields filled/empty × "Suivant" action
+- **Error Guessing**: Back button preserves data, progress bar behavior, duplicate libellé
+
+### Generated CSV Output
+
+```csv
+Test ID;Summary;Description;Repository;Preconditions;Test Steps;Expected Results;Priority;Labels
+;Accès au formulaire de création de fiche plat;Vérifier l'ouverture du formulaire via le bouton d'ajout;Paramétrage/Fiches plat/Création/;"- Utilisateur connecté avec droits Paramétrage
+- Navigation : Paramétrage > Fiches plat > contexte Plat";"1. Naviguer vers Paramétrage > Fiches plat (contexte Plat)
+2. Vérifier la présence du bouton d'ajout (icône +)
+3. Cliquer sur le bouton d'ajout
+4. Cliquer sur ""Ajouter un plat"" dans le sous-menu";"1. La liste des fiches plat existantes s'affiche
+2. Le bouton d'ajout (FAB) est visible
+3. Un sous-menu apparaît avec l'option ""Ajouter un plat""
+4. Le formulaire s'ouvre avec le titre ""Création d'une fiche plat""";High;smoke,parametrage,positive
+;Création fiche plat — parcours complet (happy path);Vérifier la création complète d'une fiche plat en remplissant les 4 volets;Paramétrage/Fiches plat/Création/;"- Utilisateur connecté avec droits Paramétrage
+- Formulaire de création ouvert
+- Aucune fiche plat ""Curry de poulet au lait de coco"" existante";"1. Saisir ""Curry de poulet au lait de coco"" dans Libellé
+2. Rechercher et sélectionner ""VVPO"" dans Famille
+3. Rechercher et sélectionner ""Viande - volaille"" dans Sous-famille
+4. Rechercher et sélectionner ""Cuisine"" dans Poste de distribution
+5. Rechercher et sélectionner ""Déclinaison sel / léger"" dans Groupe modes de préparation
+6. Cliquer sur ""Suivant""
+7. Désactiver ""Sélectionner tout"" puis sélectionner ""CHBA"", ""CHU"", ""Cité ADM""
+8. Cliquer sur ""Suivant""
+9. Sélectionner les régimes ""Ordinaire"", ""Sans gluten"", ""Sans poisson""
+10. Sélectionner les rations ""1 part"", ""1/2 part""
+11. Cliquer sur ""Suivant""
+12. Sélectionner les goûts ""tomate cuite"", ""Volaille""
+13. Cliquer sur ""Valider""";"1. Le champ Libellé accepte la saisie
+2-5. Les valeurs sont sélectionnées dans les champs respectifs
+6. Navigation vers le Volet 2 — Destinations
+7. Les 3 destinations apparaissent sélectionnées
+8. Navigation vers le Volet 3 — Régimes et Rations
+9. Les 3 régimes sont sélectionnés
+10. Les 2 rations sont sélectionnées
+11. Navigation vers le Volet 4 — Goûts
+12. Les 2 goûts sont sélectionnés
+13. Une barre de progression s'affiche, puis disparaît. La fiche plat apparaît dans le panneau de détails avec toutes les informations saisies";High;regression,parametrage,positive
+;Validation champ obligatoire — Libellé vide;Vérifier que le Volet 1 bloque la navigation si le Libellé est vide;Paramétrage/Fiches plat/Création/;"- Formulaire de création ouvert (Volet 1)";"1. Laisser le champ Libellé vide
+2. Remplir les autres champs obligatoires (Famille, Sous-famille, etc.)
+3. Cliquer sur ""Suivant""";"1. Le champ Libellé reste vide
+2. Les autres champs acceptent les valeurs
+3. Un message d'erreur indique que le champ Libellé est obligatoire. La navigation vers le Volet 2 est bloquée";High;parametrage,negative,validation
+;Navigation retour entre volets — conservation des données;Vérifier que les données saisies sont conservées lors de la navigation retour;Paramétrage/Fiches plat/Création/;"- Formulaire de création ouvert
+- Volet 1 rempli, navigation effectuée jusqu'au Volet 3";"1. Depuis le Volet 3, naviguer en arrière vers le Volet 2
+2. Vérifier les destinations sélectionnées
+3. Naviguer en arrière vers le Volet 1
+4. Vérifier les valeurs du Volet 1";"1. Le Volet 2 s'affiche
+2. Les destinations précédemment sélectionnées sont toujours cochées
+3. Le Volet 1 s'affiche
+4. Toutes les valeurs saisies (Libellé, Famille, etc.) sont conservées";Medium;parametrage,positive,functional
+;Destinations — sélectionner tout puis désélectionner individuellement;Vérifier le comportement du sélecteur tout/individuel pour les destinations;Paramétrage/Fiches plat/Création/;"- Formulaire de création ouvert
+- Navigation au Volet 2";"1. Activer ""Sélectionner tout""
+2. Vérifier que toutes les destinations sont cochées
+3. Désélectionner une destination individuellement (ex: ""CHBA"")
+4. Vérifier l'état de ""Sélectionner tout""";"1. Toutes les destinations sont sélectionnées
+2. Chaque case est cochée
+3. ""CHBA"" est désélectionné
+4. ""Sélectionner tout"" est automatiquement décoché (état indéterminé ou décoché)";Medium;parametrage,boundary,functional
+;Destinations — aucune sélection;Vérifier le comportement lorsqu'aucune destination n'est sélectionnée;Paramétrage/Fiches plat/Création/;"- Formulaire au Volet 2
+- ""Sélectionner tout"" désactivé";"1. S'assurer qu'aucune destination n'est sélectionnée
+2. Cliquer sur ""Suivant""";"1. Toutes les cases sont décochées
+2. Selon la règle métier : soit navigation vers Volet 3 autorisée, soit message de validation affiché";Medium;parametrage,boundary,negative
+```
+
+### Generated JDD Output (`SRD-FP-001.json`)
+
+```json
+{
+  "metadata": {
+    "description": "Jeux de données pour la création d'une fiche plat — Paramétrage > Fiches plat",
+    "version": "1.0.0",
+    "lastUpdated": "2026-04-17"
+  },
+  "entrants": {
+    "volet_1": {
+      "libelle": "Curry de poulet au lait de coco",
+      "platTemoin": false,
+      "platCuisineAvance": false,
+      "famillePlat": "VVPO",
+      "sousFamille": "Viande - volaille",
+      "posteDistribution": "Cuisine",
+      "grpeModePreparation": "Déclinaison sel / léger"
+    },
+    "volet_2": {
+      "destinations": ["CHBA", "CHU", "Cité ADM"]
+    },
+    "volet_3": {
+      "regimes": ["Ordinaire", "Sans gluten", "Sans poisson"],
+      "rations": ["1 part", "1/2 part"]
+    },
+    "volet_4": {
+      "gouts": ["tomate cuite", "Volaille"]
+    }
+  },
+  "sortants": {
+    "texteBtnAjoutPlat": "Ajouter un plat",
+    "texteFormCreationFP": "Création d'une fiche plat",
+    "labelsVolet1": {
+      "libelle": "Libellé",
+      "famille": "Famille",
+      "sousFamille": "Sous-famille",
+      "posteDistribution": "Poste de distribution",
+      "grpeModePreparation": "Groupe de modes de préparation"
+    },
+    "navigation": {
+      "boutonSuivant": "Suivant",
+      "boutonValider": "Valider"
+    }
+  }
+}
+```

--- a/skills/manual-test-designer/reference/jdd-generation.md
+++ b/skills/manual-test-designer/reference/jdd-generation.md
@@ -1,0 +1,173 @@
+# JDD (Jeux de Données) Generation Guide
+
+## What is JDD?
+
+JDD = **Jeux De Données** (test data files). They externalize test input and expected output data from test scripts, making tests data-driven and maintainable.
+
+## When to Generate JDD
+
+- **Always** when test cases reference specific input data (form fields, selections, values)
+- **Always** when expected results include exact UI text, labels, or messages
+- **Optionally** when the user explicitly requests test data files
+
+## File Naming Convention
+
+```
+fixtures/jdd/SRD-[MODULE_CODE]-[NNN].json
+```
+
+| Part | Description | Examples |
+|---|---|---|
+| `SRD` | Product prefix (always) | `SRD` |
+| `MODULE_CODE` | Short module identifier | `FP` (Fiches plat), `NAV` (Navigation), `AUTH` (Auth) |
+| `NNN` | Sequential number, zero-padded | `001`, `002`, `010` |
+
+**Examples**: `SRD-FP-001.json`, `SRD-NAV-001.json`, `SRD-AUTH-001.json`
+
+**Special file**: `SRD-Commun.json` — shared data used across all tests (credentials, common texts).
+
+## JSON Structure
+
+```json
+{
+  "metadata": {
+    "description": "Description fonctionnelle du jeu de données",
+    "version": "1.0.0",
+    "lastUpdated": "YYYY-MM-DD"
+  },
+  "entrants": {
+    // Input data — what the test enters/selects in the UI
+  },
+  "sortants": {
+    // Expected output — what the test verifies/asserts
+  }
+}
+```
+
+### `metadata` — File description
+
+| Field | Required | Description |
+|---|---|---|
+| `description` | Yes | What feature/test this data serves |
+| `version` | Yes | Semantic version of the data set |
+| `lastUpdated` | Yes | ISO date of last modification |
+
+### `entrants` — Input data
+
+Everything the test **types, selects, toggles, or submits** in the UI.
+
+**Organization**: Group by logical section (form volet, screen area, step).
+
+```json
+{
+  "entrants": {
+    "volet_1": {
+      "libelle": "Curry de poulet au lait de coco",
+      "platTemoin": false,
+      "famillePlat": "VVPO",
+      "sousFamille": "Viande - volaille"
+    },
+    "volet_2": {
+      "destinations": ["CHBA", "CHU", "Cité ADM"]
+    }
+  }
+}
+```
+
+**Data type mapping**:
+
+| UI element | JSON type | Example |
+|---|---|---|
+| Text input | `string` | `"Curry de poulet"` |
+| Toggle/checkbox | `boolean` | `false` |
+| Single-select dropdown | `string` | `"VVPO"` |
+| Multi-select | `string[]` | `["CHBA", "CHU"]` |
+| Numeric input | `number` | `42` |
+| Date picker | `string` (ISO) | `"2026-04-17"` |
+
+### `sortants` — Expected output
+
+Everything the test **verifies, asserts, or checks** in the UI.
+
+```json
+{
+  "sortants": {
+    "texteBtnAjoutPlat": "Ajouter un plat",
+    "texteFormCreationFP": "Création d'une fiche plat",
+    "messageErreurLibelleVide": "Le champ Libellé est obligatoire",
+    "titrePageAccueil": "Accueil"
+  }
+}
+```
+
+**Naming convention for sortants**:
+- `texte[Element]` — expected text content: `texteFormCreationFP`
+- `message[Type][Context]` — expected message: `messageErreurLibelleVide`
+- `titre[Page]` — page/section title: `titrePageAccueil`
+- `label[Field]` — expected label text: `labelBoutonSuivant`
+- `count[Element]` — expected count: `countDestinations`
+
+## Mapping Entrants/Sortants to Test Steps
+
+| Test step action | Maps to | JDD section |
+|---|---|---|
+| Saisir "Curry de poulet" dans Libellé | `entrants.volet_1.libelle` | entrants |
+| Sélectionner "VVPO" dans Famille | `entrants.volet_1.famillePlat` | entrants |
+| Vérifier le titre "Création d'une fiche plat" | `sortants.texteFormCreationFP` | sortants |
+| Vérifier le message d'erreur | `sortants.messageErreurLibelleVide` | sortants |
+
+## Complete Example
+
+For the dish creation feature (ERPPASTEST-127):
+
+```json
+{
+  "metadata": {
+    "description": "Jeux de données pour la création d'une fiche plat — Paramétrage",
+    "version": "1.0.0",
+    "lastUpdated": "2026-04-17"
+  },
+  "entrants": {
+    "volet_1": {
+      "libelle": "Curry de poulet au lait de coco",
+      "platTemoin": false,
+      "platCuisineAvance": false,
+      "famillePlat": "VVPO",
+      "sousFamille": "Viande - volaille",
+      "posteDistribution": "Cuisine",
+      "grpeModePreparation": "Déclinaison sel / léger"
+    },
+    "volet_2": {
+      "destinations": ["CHBA", "CHU", "Cité ADM"]
+    },
+    "volet_3": {
+      "regimes": ["Ordinaire", "Sans gluten", "Sans poisson"],
+      "rations": ["1 part", "1/2 part"]
+    },
+    "volet_4": {
+      "gouts": ["tomate cuite", "Volaille"]
+    }
+  },
+  "sortants": {
+    "texteBtnAjoutPlat": "Ajouter un plat",
+    "texteFormCreationFP": "Création d'une fiche plat",
+    "labelsVolet1": {
+      "libelle": "Libellé",
+      "famille": "Famille",
+      "sousFamille": "Sous-famille",
+      "posteDistribution": "Poste de distribution",
+      "grpeModePreparation": "Groupe de modes de préparation"
+    }
+  }
+}
+```
+
+## Anti-patterns
+
+| Anti-pattern | Problem | Fix |
+|---|---|---|
+| Hardcoded data in test scripts | Changes require code edits | Extract to JDD JSON |
+| Flat structure | Hard to find data for specific form section | Group by volet/section |
+| Missing sortants | Tests don't verify expected results | Always include expected texts/labels |
+| Duplicated common data | Credentials in every JDD file | Use `SRD-Commun.json` for shared data |
+| Generic values | `"test"`, `"abc123"` | Use realistic domain data |

--- a/skills/manual-test-designer/reference/test-design-techniques.md
+++ b/skills/manual-test-designer/reference/test-design-techniques.md
@@ -1,0 +1,181 @@
+# Test Design Techniques — When and How to Apply
+
+## Decision Matrix
+
+Use this table to decide which techniques to apply based on what you find in the input.
+
+| Technique | Apply when... | Skip when... |
+|---|---|---|
+| Equivalence Partitioning (EP) | Any field accepts input (text, dropdown, toggle) | Field has only one valid value |
+| Boundary Value Analysis (BVA) | Numeric fields, string lengths, dates, list sizes, pagination | Boolean fields, fixed dropdowns with few options |
+| Decision Tables | 2+ conditions interact to produce different outcomes | Conditions are independent |
+| State Transition | Multi-step workflows, status changes, wizard forms | Single-screen CRUD without state |
+| Pairwise Testing | 3+ independent input parameters with multiple values each | Fewer than 3 parameters |
+| Error Guessing | Always — after applying formal techniques | Never skip this |
+
+---
+
+## Technique 1: Equivalence Partitioning (EP)
+
+**Principle**: Divide input values into classes where all values in a class should produce the same behavior. Test ONE value per class.
+
+**Classes to identify**:
+- Valid class(es)
+- Invalid class(es): empty, wrong type, too long, special characters, injection attempts
+- Boundary class(es): min, max, just below min, just above max
+
+**SRD Example — "Libellé" field (dish name)**:
+
+| Class | Example value | Expected behavior |
+|---|---|---|
+| Valid (normal) | "Curry de poulet au lait de coco" | Accepted |
+| Valid (minimum) | "A" | Accepted (if 1-char allowed) |
+| Empty | "" | Validation error: champ obligatoire |
+| Special characters | "<script>alert('x')</script>" | Sanitized or rejected |
+| Very long string | 500+ characters | Validation error or truncation |
+
+**Rule**: One test case per class. Do NOT create 5 tests with different valid names — they're all in the same class.
+
+---
+
+## Technique 2: Boundary Value Analysis (BVA)
+
+**Principle**: Bugs cluster at boundaries. Test the exact boundary values: min, min+1, max-1, max, min-1, max+1.
+
+**Apply to**:
+- Numeric fields (quantities, prices, ages)
+- String length limits
+- Date ranges (start date, end date)
+- List sizes (minimum selections, maximum selections)
+- Pagination (first page, last page, page 0, page beyond max)
+
+**SRD Example — "Destinations" multi-select (Volet 2)**:
+
+| Boundary | Value | Expected |
+|---|---|---|
+| None selected | 0 destinations | Validation error or allowed (depends on business rule) |
+| One selected | 1 destination ("CHBA") | Accepted |
+| All selected | All destinations via "Sélectionner tout" | Accepted |
+| Deselect all after selecting | 0 after having N | State returns to empty |
+
+---
+
+## Technique 3: Decision Tables
+
+**Principle**: When multiple conditions combine to determine the outcome, enumerate all meaningful combinations.
+
+**When to build one**:
+- Login with valid/invalid username × valid/invalid password
+- Form submission with combination of mandatory fields filled/empty
+- Access control: role × module × action
+
+**SRD Example — Login conditions**:
+
+| # | Username | Password | Expected |
+|---|---|---|---|
+| 1 | Valid | Valid | Connexion réussie → page d'accueil |
+| 2 | Valid | Invalid | Message d'erreur |
+| 3 | Invalid | Valid | Message d'erreur |
+| 4 | Invalid | Invalid | Message d'erreur |
+| 5 | Empty | Empty | Validation: champs obligatoires |
+| 6 | Valid | Empty | Validation: mot de passe obligatoire |
+| 7 | Empty | Valid | Validation: identifiant obligatoire |
+
+**Rule**: Collapse rows that produce identical outcomes (rows 2-4 could be one test if the error message is the same). Keep them separate if the error messages differ.
+
+---
+
+## Technique 4: State Transition
+
+**Principle**: Model the system as states + transitions. Test each valid transition, invalid transitions, and sequences.
+
+**Apply to**:
+- Multi-step wizard forms (Volet 1 → 2 → 3 → 4)
+- Status workflows (Draft → Submitted → Approved → Published)
+- Session states (Logged out → Logged in → Timed out)
+- UI states (Sidebar collapsed → expanded)
+
+**SRD Example — Multi-volet dish creation form**:
+
+```
+States: [V1: Informations] → [V2: Destinations] → [V3: Régimes/Rations] → [V4: Goûts/Validation]
+
+Valid transitions:
+  V1 → V2 (click "Suivant" with all required fields)
+  V2 → V3 (click "Suivant")
+  V3 → V4 (click "Suivant")
+  V4 → Saved (click "Valider")
+  V2 → V1 (navigate back)
+  V3 → V2 (navigate back)
+  V4 → V3 (navigate back)
+
+Invalid transitions:
+  V1 → V2 (click "Suivant" with empty required fields → blocked, error shown)
+  V4 → Saved (click "Valider" with missing data → blocked)
+```
+
+**Test cases to generate**:
+1. Happy path: V1 → V2 → V3 → V4 → Saved
+2. Back navigation preserves data: V1 → V2 → V1 (data still present)
+3. Blocked transition: V1 → V2 with empty "Libellé" → error
+4. Full round-trip: V1 → V2 → V3 → V2 → V1 → V2 → V3 → V4 → Saved
+
+---
+
+## Technique 5: Pairwise Testing
+
+**Principle**: When testing all combinations is impractical (N parameters × M values = explosion), test all pairs of parameter values. Covers most interaction bugs with far fewer tests.
+
+**Apply when**: 3+ independent parameters each have 2+ possible values.
+
+**SRD Example — Volet 1 fields**:
+
+Parameters: Famille (3 values), Sous-famille (4 values), Poste de distribution (3 values), Groupe modes préparation (2 values)
+
+Full combinatorial: 3 × 4 × 3 × 2 = 72 tests
+Pairwise: ~12 tests covering all pairs
+
+**How to construct**: Use an orthogonal array or pairwise generation tool. List all parameter values, then select a minimal set of combinations that covers every pair.
+
+---
+
+## Technique 6: Error Guessing
+
+**Principle**: Based on experience, probe areas where defects commonly hide. Apply AFTER formal techniques.
+
+**Common error-prone areas**:
+- Empty/null/whitespace-only inputs
+- Copy-paste with hidden characters
+- Double-click / double-submit
+- Browser back button during multi-step forms
+- Session timeout mid-form
+- Concurrent modifications (two users editing same record)
+- Special characters in search fields: `' " < > & / \`
+- Very fast repeated actions (race conditions)
+- Network interruption during save
+
+**SRD-specific error guessing**:
+- Loader/progress bar doesn't disappear after save
+- Sidebar state lost after navigation
+- Multi-select "Sélectionner tout" then individual deselect — count mismatch
+- Creating a dish with a name that already exists (uniqueness constraint)
+- Navigating away during "Chargement du module en cours..."
+
+---
+
+## Risk-Based Prioritization
+
+After generating test cases, assign priorities using this risk assessment:
+
+| Risk factor | High risk (P0) | Medium risk (P1) | Low risk (P2) |
+|---|---|---|---|
+| Business impact | Data loss, financial, compliance | Workflow blocked, workaround exists | Cosmetic, convenience |
+| Usage frequency | Used by all users daily | Used regularly by subset | Rarely used |
+| Complexity | Complex integrations, calculations | Moderate logic | Simple display |
+| Defect history | Known buggy area | Some past issues | Stable area |
+| Visibility | Customer-facing, demo path | Internal users | Admin-only |
+
+**Rule of thumb for test distribution**:
+- P0: ~20% of tests (critical path, smoke)
+- P1: ~50% of tests (core functional, regression)
+- P2: ~30% of tests (edges, boundaries, comfort)

--- a/skills/qa-automation/SKILL.md
+++ b/skills/qa-automation/SKILL.md
@@ -1,0 +1,74 @@
+---
+name: qa-automation
+description: "Expert Playwright/TypeScript test automation using a 3-layer architecture (spec → steps → POM), fixture dependency injection, and JDD test data (entrants/sortants). Use when creating, modifying, or debugging Playwright tests, page objects, step files, fixtures, or test data in projects following this architecture."
+version: 2.0.0
+---
+
+# QA Automation — Playwright 3-Layer Architecture
+
+## Architecture (mandatory for all projects)
+
+```
+tests/**/*.spec.ts          ← Layer 1: Specs (orchestration only)
+    ↓ uses fixture
+src/utils/fixtures/*.ts     ← Dependency injection (NO new elsewhere)
+    ↓ injects
+src/steps/**/*.ts           ← Layer 2: Steps (business logic, no locators)
+    ↓ calls
+src/pages/**/*.ts           ← Layer 3: POM (locators + UI interactions)
+    ↑
+fixtures/jdd/*.json         ← Test data: entrants (inputs) / sortants (expected)
+```
+
+## Golden Rules
+
+1. `new PageX()` and `new StepsX()` — **ONLY inside fixture files**
+2. **Locators** — ONLY in POM (Layer 3), never in specs or steps
+3. **Business logic** — ONLY in Steps (Layer 2), never in specs
+4. **Specs** — orchestration only: call step methods, pass JDD data
+5. **JDD** — externalize ALL test data; no hardcoded strings in specs or steps
+6. **Typed** — use TypeScript interfaces for JDD data, avoid `any`
+
+## Workflow — Adding/Modifying Tests
+
+### Step 1 — Discover the project
+
+Explore the codebase: read existing fixtures, steps, pages, enums, types, and `conf.json` to understand available navigation, components, and conventions.
+
+### Step 2 — Identify which layer to modify
+
+| Task | Layer | File pattern |
+|---|---|---|
+| New UI interaction | POM | `src/pages/[module]/Page*.ts` |
+| New business flow | Steps | `src/steps/[module]/Etapes*.ts` |
+| New test scenario | Spec | `tests/[module]/*.spec.ts` |
+| New test data | JDD | `fixtures/jdd/[PRODUCT]-[MODULE]-[NNN].json` |
+| New module wiring | Fixture | `src/utils/fixtures/[module].fixtures.ts` |
+
+### Step 3 — Implement following layer rules
+
+See [architecture guide](reference/architecture.md) for layer-by-layer rules and examples.
+
+### Step 4 — Wire fixtures
+
+Register new pages/steps in the module's fixture file. See [architecture guide](reference/architecture.md#fixture-composition).
+
+### Step 5 — Write/update spec
+
+Use proper tags, annotations, and JDD imports. See [patterns](reference/patterns.md).
+
+### Step 6 — Verify
+
+Run tests, check Allure report, validate assertions. See [checklist](reference/checklist.md).
+
+## Key References
+
+- [Architecture guide](reference/architecture.md) — layers, fixtures, environment config
+- [Code patterns](reference/patterns.md) — forms, navigation, CRUD, reporting, anti-patterns
+- [Locator strategy](reference/locator-strategy.md) — accessibility-first, custom locators, waits
+- [Test data (JDD)](reference/test-data.md) — entrants/sortants, typing, naming, cleanup
+- [Checklist & CI/CD](reference/checklist.md) — new feature checklist, tagging, debugging, CI
+
+## Integration
+
+The `manual-test-designer` skill generates Xray-compatible CSV test cases. Use those as input to scaffold automated tests following this architecture.

--- a/skills/qa-automation/docs/qa-automation.md
+++ b/skills/qa-automation/docs/qa-automation.md
@@ -1,0 +1,101 @@
+# QA Automation
+
+## Description
+
+Skill d'automatisation de tests end-to-end avec Playwright et TypeScript, basé sur une architecture 3 couches stricte (spec → steps → POM) avec injection de dépendances par fixtures et données de test externalisées (JDD entrants/sortants).
+
+Ce skill guide l'agent dans la création, la modification et le débogage de tests automatisés en suivant les conventions d'architecture établies. Il est générique et applicable à tout projet Playwright utilisant cette architecture.
+
+## Cas d'usage
+
+- Créer un nouveau test automatisé pour une fonctionnalité
+- Ajouter un Page Object (POM) pour une nouvelle page/composant
+- Écrire des Steps (étapes) encapsulant la logique métier
+- Câbler les fixtures d'injection de dépendances pour un nouveau module
+- Créer ou modifier les jeux de données de test (JDD)
+- Déboguer un test qui échoue ou qui est instable (flaky)
+- Configurer l'intégration CI/CD (Jenkins, GitHub Actions)
+
+## Déclenchement
+
+Le skill s'active quand l'utilisateur :
+- Demande de « créer un test Playwright » ou « automatiser un scénario »
+- Veut « ajouter un page object » ou « créer une page POM »
+- Mentionne « fixture », « steps », « étapes de test »
+- Demande de « déboguer un test » ou « corriger un test flaky »
+- Veut « câbler un nouveau module » dans les fixtures
+- Parle de « JDD », « données de test », « entrants/sortants »
+
+## Fonctionnement
+
+### Architecture 3 couches
+
+```
+tests/**/*.spec.ts          ← Couche 1 : Specs (orchestration uniquement)
+src/utils/fixtures/*.ts     ← Injection de dépendances
+src/steps/**/*.ts           ← Couche 2 : Steps (logique métier, pas de locators)
+src/pages/**/*.ts           ← Couche 3 : POM (locators + interactions UI)
+fixtures/jdd/*.json         ← Données de test (entrants/sortants)
+```
+
+### Workflow en 6 étapes
+
+1. **Découvrir** — Explorer le code existant (fixtures, steps, pages, enums, types)
+2. **Identifier la couche** — Déterminer quel fichier modifier selon la tâche
+3. **Implémenter** — Suivre les règles strictes de chaque couche
+4. **Câbler les fixtures** — Enregistrer les nouvelles pages/steps dans les fixtures
+5. **Écrire le spec** — Orchestrer avec tags, annotations et données JDD
+6. **Vérifier** — Exécuter, vérifier le rapport Allure, valider les assertions
+
+### Règles d'or
+
+1. `new PageX()` et `new StepsX()` — **UNIQUEMENT dans les fichiers fixture**
+2. **Locators** — UNIQUEMENT dans le POM (Couche 3)
+3. **Logique métier** — UNIQUEMENT dans les Steps (Couche 2)
+4. **Specs** — orchestration uniquement, pas de logique
+5. **JDD** — externaliser TOUTES les données de test
+6. **Typage strict** — interfaces TypeScript pour les JDD, jamais `any`
+
+## Configuration par défaut
+
+| Paramètre | Valeur |
+|---|---|
+| Framework | Playwright + TypeScript |
+| Pattern | Page Object Model + Component Object Model |
+| Injection | Fixtures Playwright (test.extend) |
+| Données | JDD JSON (entrants/sortants) |
+| Rapports | Allure + JUnit (Xray) + HTML |
+| Stratégie de locators | Accessibilité d'abord (getByRole > getByLabel > CSS) |
+
+## Exemples
+
+### Spec (Couche 1)
+```typescript
+import { test } from "../../src/utils/fixtures/module.fixtures";
+import * as jdd from "../../fixtures/jdd/PRODUCT-MODULE-001.json";
+
+test("XRAY-NNN TC_PRODUCT_MODULE_Test", {
+  tag: "@XRAY-NNN",
+  annotation: [{ type: "test_key", description: "XRAY-NNN" }],
+}, async ({ etapesFeature }) => {
+  await etapesFeature.navigateToFeature();
+  await etapesFeature.createItem(jdd.entrants, jdd.sortants);
+});
+```
+
+### POM (Couche 3)
+```typescript
+export class PageFeature extends BasePage {
+  get submitButton() { return this.page.getByRole("button", { name: "Valider" }); }
+  inputByLabel(label: string) { return this.page.getByLabel(label); }
+}
+```
+
+## Intégration
+
+- Le skill `manual-test-designer` génère des cas de test CSV → ce skill les automatise
+- Les résultats sont exportés vers Xray via JUnit XML (`results/junit/results.xml`)
+
+## Version
+
+2.0.0

--- a/skills/qa-automation/reference/architecture.md
+++ b/skills/qa-automation/reference/architecture.md
@@ -1,0 +1,336 @@
+# Architecture Guide — 3-Layer Playwright Framework
+
+## Layer Overview
+
+Every project follows this strict separation:
+
+```
+tests/**/*.spec.ts          ← Layer 1: Specs (orchestration ONLY)
+    ↓ imports fixture
+src/utils/fixtures/*.ts     ← Fixture DI layer (wiring ONLY)
+    ↓ injects into
+src/steps/**/*.ts           ← Layer 2: Steps (business logic, NO locators)
+    ↓ calls methods on
+src/pages/**/*.ts           ← Layer 3: POM (locators + UI actions ONLY)
+    ↑ reads
+fixtures/jdd/*.json         ← Test data: entrants / sortants
+```
+
+---
+
+## Layer 1 — Spec Files
+
+**Location**: `tests/[module]/*.spec.ts`
+
+**Rules**:
+- Import `test` from the **module fixture**, never from `@playwright/test` directly
+- Import JDD data as `* as jdd`
+- Orchestration only — call step methods, never interact with the page directly
+- Each test has: Xray tag, `test_key` + `test_summary` annotations
+- Describe blocks use suite tags: `@regression`, `@smoke`, `@featureTag`
+
+```typescript
+import { test } from "../../src/utils/fixtures/module.fixtures";
+import * as jdd from "../../fixtures/jdd/PRODUCT-MODULE-001.json";
+
+test.describe("Feature — Description", { tag: ["@regression", "@feature"] }, () => {
+  test(
+    "XRAY-KEY-NNN TC_PRODUCT_MODULE_Test_name",
+    {
+      tag: "@XRAY-KEY-NNN",
+      annotation: [
+        { type: "test_key", description: "XRAY-KEY-NNN" },
+        { type: "test_summary", description: "TC_PRODUCT_MODULE_Test_name" },
+      ],
+    },
+    async ({ etapesFeature }) => {
+      await etapesFeature.navigateToFeature();
+      await etapesFeature.performAction(jdd.entrants, jdd.sortants);
+    }
+  );
+});
+```
+
+**What NEVER belongs in a spec**:
+- `page.locator(...)` — use step methods
+- `await page.click(...)` — use step methods
+- Hard-coded strings — use JDD `sortants`
+- Business logic or conditionals — move to steps
+- `new PageX(page)` — only in fixtures
+
+---
+
+## Layer 2 — Steps Files
+
+**Location**: `src/steps/[module]/[feature]/EtapesFeature.ts`
+
+**Rules**:
+- Receives page objects via constructor injection (from fixtures)
+- Contains business logic and test flow orchestration
+- NEVER contains locators or direct `page.locator()` calls
+- Uses `logger` for Allure step reporting
+- Methods accept `entrants` (inputs) and `sortants` (expected outputs)
+
+```typescript
+import { logger } from "@utils/Logger";
+
+export class EtapesFeature {
+  constructor(
+    private readonly navigation: Navigation,
+    private readonly pageFeature: PageFeature
+  ) {}
+
+  async navigateToFeature(): Promise<void> {
+    await this.navigation.navigateToHome();
+    await this.navigation.goToSubMenu(
+      EntryPoint.MODULE_NAME,
+      SubMenuItem.FEATURE_NAME,
+      ContextSelection.CONTEXT_NAME
+    );
+  }
+
+  async createItem(entrants: FeatureEntrants, sortants: FeatureSortants): Promise<void> {
+    logger.step(`Creating item: "${entrants.field}"`);
+    await this.pageFeature.fillForm(entrants);
+    await this.pageFeature.submitForm();
+    await this.pageFeature.verifyCreation(sortants);
+    logger.success(`Item created: "${entrants.field}"`);
+  }
+}
+```
+
+**What NEVER belongs in steps**:
+- `this.page.locator(...)` — delegate to POM
+- CSS selectors or XPath — delegate to POM
+- Direct Playwright API calls — delegate to POM
+
+---
+
+## Layer 3 — Page Objects (POM)
+
+**Location**: `src/pages/[module]/PageFeature.ts`
+
+**Rules**:
+- Extends `BasePage` (shared base with common utilities)
+- Locators defined as **getters** (simple) or **methods** (parameterized)
+- Contains ONLY UI interaction logic (click, fill, select, assert visibility)
+- Uses accessibility-first locator strategy (see [locator-strategy.md](locator-strategy.md))
+- Never contains business flow logic — that belongs in steps
+
+```typescript
+import { BasePage, HeaderAction } from "../core/BasePage";
+import type { FeatureEntrants, FeatureSortants } from "@types";
+
+export class PageFeature extends BasePage {
+  // Simple locators as getters
+  get addButton() { return this.page.getByRole("button", { name: "Add" }); }
+  get formTitle() { return this.page.getByRole("heading", { level: 2 }); }
+
+  // Parameterized locators as methods
+  inputByLabel(label: string) {
+    return this.page.getByLabel(label);
+  }
+
+  // UI interaction methods
+  async fillForm(entrants: FeatureEntrants): Promise<void> {
+    await this.inputByLabel("Label").fill(entrants.label);
+    await this.setToggleByLabel(entrants.toggleValue, "Toggle field");
+    await this.searchAndSelect("Category", entrants.category);
+    await this.headerActionBtn(HeaderAction.SUIVANT).click();
+  }
+
+  async submitForm(): Promise<void> {
+    await this.headerActionBtn(HeaderAction.VALIDER).click();
+    await this.waitForLoaderToFinish(this.internalProgressBar);
+  }
+
+  async verifyCreation(sortants: FeatureSortants): Promise<void> {
+    await expect(this.formTitle).toContainText(sortants.successTitle);
+  }
+}
+```
+
+---
+
+## BasePage — Common Utilities
+
+Every POM extends `BasePage` which provides:
+
+```typescript
+// Waiting
+waitForWebSocketIdle(idleTime?, maxTimeout?)     // After navigation
+waitForLoaderToFinish(loader: Locator)            // After saves
+waitForLoaderDuringAction(action, loader)         // Wrap async action
+checkPageCompletelyLoaded()                       // Full page ready
+
+// Navigation
+navigateTo(url: string)
+goto() / reload() / goBack() / goForward()
+getCurrentUrl() / getTitle()
+
+// Form helpers
+setToggleByLabel(shouldBeChecked: boolean, label: string)
+headerActionBtn(action: HeaderAction): Locator    // "Suivant", "Valider"
+confirmDeletion(action: "Continuer" | "Abandonner")
+
+// DOM utilities
+getText(locator) / getValue(locator) / getInnerText(locator)
+
+// Storage
+setLocalStorage(key, value) / getLocalStorage(key) / clearLocalStorage()
+
+// Debug
+takeScreenshot(name: string)
+handleDialog(action: "accept" | "dismiss", promptText?: string)
+
+// Allure
+step(message: string) / log(message: string)
+
+// Common locators (project-specific, check BasePage for actual selectors)
+internalProgressBar / confirmationModal / moduleLoading / dataLoading
+```
+
+**Important**: BasePage locators (progress bars, modals, loaders) are project-specific. Always read the project's `BasePage.ts` to discover available selectors and methods.
+
+---
+
+## Fixture Composition {#fixture-composition}
+
+Fixtures wire pages and steps together using Playwright's dependency injection.
+
+### Base: `commons.fixtures.ts`
+
+Provides core fixtures available to all modules:
+
+```typescript
+import { test as base, expect } from "@playwright/test";
+import { PageConnexion } from "@pages/auth/PageConnexion";
+import { Navigation } from "@pages/core/components/ActionBar";
+import { SideBar } from "@pages/core/components/SideBar";
+import { CommonSteps } from "@steps/CommonSteps";
+
+// Internal pages (prefixed _, not accessible in specs)
+interface _CorePageFixtures {
+  _pageConnexion: PageConnexion;
+  _navigation: Navigation;
+  _sideBar: SideBar;
+}
+
+// Public steps (accessible in specs via async ({ commonSteps }) => {})
+export interface CoreStepFixtures {
+  commonSteps: CommonSteps;
+}
+
+export const test = base.extend<_CorePageFixtures & CoreStepFixtures>({
+  _pageConnexion: async ({ page }, use) => { await use(new PageConnexion(page)); },
+  _navigation: async ({ page }, use) => { await use(new Navigation(page)); },
+  _sideBar: async ({ page }, use) => { await use(new SideBar(page)); },
+  commonSteps: async ({ _pageConnexion, _navigation, _sideBar }, use) => {
+    await use(new CommonSteps(_pageConnexion, _navigation, _sideBar));
+  },
+});
+export { expect };
+```
+
+### Module: `[module].fixtures.ts`
+
+Extends commons with module-specific pages and steps:
+
+```typescript
+import { test as baseTest, expect } from "./commons.fixtures";
+import { PageFeature } from "@pages/module/PageFeature";
+import { EtapesFeature } from "@steps/module/feature/EtapesFeature";
+
+// Internal pages (wiring only)
+interface _ModulePageFixtures {
+  pageFeature: PageFeature;
+}
+
+// Public steps (exposed to specs)
+export interface ModuleStepFixtures {
+  etapesFeature: EtapesFeature;
+}
+
+export const test = baseTest.extend<_ModulePageFixtures & ModuleStepFixtures>({
+  pageFeature: async ({ page }, use) => { await use(new PageFeature(page)); },
+  etapesFeature: async ({ _navigation, pageFeature }, use) => {
+    await use(new EtapesFeature(_navigation, pageFeature));
+  },
+});
+export { expect };
+```
+
+### Convention: Private vs Public Fixtures
+
+| Prefix | Visibility | Purpose |
+|---|---|---|
+| `_` prefix (`_navigation`) | Internal only | Injected into steps, NOT accessible in spec body |
+| No prefix (`commonSteps`) | Public | Accessible in `async ({ commonSteps }) => {}` |
+
+**Composition chain**: `commons.fixtures` → `module.fixtures` → spec imports from module fixture.
+
+---
+
+## Environment Configuration
+
+### `fixtures/conf.json`
+
+```json
+{
+  "environments": {
+    "dev": {
+      "baseUrl": "https://dev.example.com",
+      "defaultPage": "https://dev.example.com/app#home",
+      "modulePage": "https://dev.example.com/app#module"
+    },
+    "staging": { "..." : "..." },
+    "production": { "..." : "..." }
+  }
+}
+```
+
+### Environment Resolution
+
+```typescript
+// Resolution order: TEST_ENV > ENVIRONMENT > default fallback
+// Local: set in .env file → TEST_ENV=dev
+// CI: set via pipeline variable → -e TEST_ENV=staging
+
+getEnvUrl("defaultPage")   // → resolves to current env's defaultPage URL
+getEnvUrl("modulePage")    // → resolves to current env's modulePage URL
+```
+
+**Important**: Always read the project's `framework.config.ts` and `conf.json` to discover available environment keys and URL patterns.
+
+---
+
+## Path Aliases
+
+All projects use TypeScript path aliases (from `tsconfig.json`):
+
+```typescript
+"@pages/*"    → "src/pages/*"
+"@steps/*"    → "src/steps/*"
+"@utils/*"    → "src/utils/*"
+"@fixtures/*" → "src/utils/fixtures/*"  // or "fixtures/*" depending on project
+```
+
+**Always use aliases** in imports — never use brittle relative paths like `../../../src/pages/`.
+
+---
+
+## Project Discovery Checklist
+
+When working on a new project for the first time, explore these files to understand the conventions:
+
+```
+[ ] fixtures/conf.json               → Environment URLs and keys
+[ ] src/config/framework.config.ts   → Env resolution logic, URL helpers
+[ ] src/pages/core/BasePage.ts       → Available base methods and locators
+[ ] src/pages/core/components/       → Navigation, sidebar, action bar enums
+[ ] src/types/                       → TypeScript interfaces, navigation config
+[ ] src/utils/fixtures/              → Existing fixture composition
+[ ] src/steps/CommonSteps.ts         → Shared step methods (login, logout)
+[ ] playwright.config.ts             → Projects, reporters, timeouts, retries
+[ ] tsconfig.json                    → Path aliases
+```

--- a/skills/qa-automation/reference/checklist.md
+++ b/skills/qa-automation/reference/checklist.md
@@ -1,0 +1,289 @@
+# Checklist, CI/CD & Debugging
+
+## New Feature Checklist
+
+When adding automated tests for a new feature, follow these steps in order:
+
+```
+[ ] 1. Create JDD file           fixtures/jdd/[PRODUCT]-[MODULE]-NNN.json
+[ ] 2. Create TypeScript types    src/types/[feature].types.ts (entrants/sortants interfaces)
+[ ] 3. Create Page Object         src/pages/[module]/PageFeature.ts (extends BasePage)
+[ ] 4. Export from page index     src/pages/[module]/index.ts
+[ ] 5. Create Steps file          src/steps/[module]/[feature]/EtapesFeature.ts
+[ ] 6. Export from steps index    src/steps/index.ts
+[ ] 7. Create/update fixture      src/utils/fixtures/[module].fixtures.ts
+[ ] 8. Export from fixture index  src/utils/fixtures/index.ts
+[ ] 9. Create spec file           tests/[module]/feature.spec.ts
+[ ] 10. Run and verify            npx playwright test tests/[module]/feature.spec.ts
+```
+
+### Naming Conventions
+
+| Layer | File pattern | Class pattern |
+|---|---|---|
+| POM | `PageFeatureName.ts` | `class PageFeatureName extends BasePage` |
+| Steps | `EtapesFeatureName.ts` | `class EtapesFeatureName` |
+| Fixture | `module.fixtures.ts` | exported `test` and `expect` |
+| Spec | `featureName.spec.ts` | `test.describe(...)` |
+| JDD | `PRODUCT-MODULE-NNN.json` | N/A |
+| Types | `feature.types.ts` | `interface FeatureEntrants` / `interface FeatureSortants` |
+
+---
+
+## Test Tagging Strategy
+
+### Tag Hierarchy
+
+```typescript
+// Suite-level tags (on test.describe)
+test.describe("Feature", { tag: ["@regression", "@moduleName"] }, () => {
+
+  // Test-level tags (on individual test)
+  test("Test name", { tag: "@XRAY-KEY-NNN" }, async () => {});
+});
+```
+
+### Standard Tags
+
+| Tag | Purpose | Runs when |
+|---|---|---|
+| `@smoke` | Critical path, must-pass | Every pipeline run |
+| `@regression` | Full regression coverage | Nightly / release |
+| `@moduleName` | Module grouping | Module-specific runs |
+| `@XRAY-KEY-NNN` | Xray traceability | Single test by key |
+| `@wip` | Work in progress | Excluded from CI |
+
+### Running by Tag
+
+```bash
+npx playwright test --grep @smoke
+npx playwright test --grep @regression
+npx playwright test --grep @XRAY-KEY-127
+npx playwright test --grep-invert @wip
+```
+
+---
+
+## Running Tests
+
+### Local Development
+
+```bash
+# All tests
+npx playwright test
+
+# Specific file
+npx playwright test tests/module/feature.spec.ts
+
+# Specific test by name
+npx playwright test -g "test name pattern"
+
+# By tag
+npx playwright test --grep @smoke
+
+# With specific environment
+TEST_ENV=dev npx playwright test
+
+# Headed mode (see the browser)
+npx playwright test --headed
+
+# UI mode (interactive)
+npx playwright test --ui
+
+# Debug mode (step-by-step)
+npx playwright test --debug
+```
+
+### CI Pipeline
+
+```bash
+# Typical CI command
+TEST_ENV=staging npx playwright test --grep @regression --reporter=list,junit,allure-playwright
+
+# Smoke tests only (fast gate)
+TEST_ENV=staging npx playwright test --grep @smoke
+
+# With retries
+npx playwright test --retries=2
+```
+
+---
+
+## Debugging Guide
+
+### 1. Trace Viewer (post-mortem)
+
+Traces are captured automatically on failure (configured in `playwright.config.ts`).
+
+```bash
+# Open trace for a failed test
+npx playwright show-trace test-results/test-name/trace.zip
+```
+
+The trace shows: screenshots at each step, DOM snapshots, network requests, console logs.
+
+### 2. Headed Mode (watch it run)
+
+```bash
+npx playwright test --headed tests/module/feature.spec.ts
+```
+
+### 3. Inspector (step-by-step)
+
+```bash
+npx playwright test --debug tests/module/feature.spec.ts
+```
+
+Opens the Playwright Inspector: step through actions, inspect locators, explore the DOM.
+
+### 4. Pause in Code
+
+Add `await page.pause()` temporarily in a test to open the inspector mid-execution:
+
+```typescript
+async ({ etapesFeature, page }) => {
+  await etapesFeature.navigateToFeature();
+  await page.pause(); // Opens inspector HERE — remove before commit
+  await etapesFeature.createItem(jdd.entrants, jdd.sortants);
+}
+```
+
+### 5. Screenshot on Demand
+
+```typescript
+await this.takeScreenshot("debug-state"); // Saved to test-results/
+```
+
+### 6. Verbose Logging
+
+```bash
+DEBUG=pw:api npx playwright test tests/module/feature.spec.ts
+```
+
+---
+
+## CI/CD Integration Patterns
+
+### Playwright Config for CI
+
+Key settings that differ between local and CI:
+
+```typescript
+// playwright.config.ts
+export default defineConfig({
+  retries: process.env.CI ? 2 : 1,
+  workers: process.env.CI ? 1 : undefined,  // Serial in CI, parallel locally
+  use: {
+    trace: "on-first-retry",        // Capture traces only on retry
+    screenshot: "only-on-failure",   // Screenshots only when tests fail
+    video: "retain-on-failure",      // Video only when tests fail
+  },
+  reporter: [
+    ["list"],
+    ["html", { open: "never" }],                              // HTML report
+    ["allure-playwright"],                                     // Allure report
+    ["junit", { outputFile: "results/junit/results.xml" }],   // Xray import
+  ],
+});
+```
+
+### Jenkins Pipeline (typical)
+
+```groovy
+stage('E2E Tests') {
+  steps {
+    sh 'npm ci'
+    sh 'npx playwright install --with-deps chromium'
+    sh "TEST_ENV=${params.ENVIRONMENT} npx playwright test --grep @regression"
+  }
+  post {
+    always {
+      junit 'results/junit/results.xml'
+      allure includeProperties: false, results: [[path: 'allure-results']]
+      publishHTML(target: [reportDir: 'playwright-report', reportFiles: 'index.html'])
+    }
+  }
+}
+```
+
+### GitHub Actions (typical)
+
+```yaml
+- name: Run Playwright tests
+  run: npx playwright test --grep @regression
+  env:
+    TEST_ENV: staging
+- uses: actions/upload-artifact@v4
+  if: always()
+  with:
+    name: test-results
+    path: |
+      playwright-report/
+      allure-results/
+      results/junit/results.xml
+```
+
+---
+
+## Test Isolation & Parallel Safety
+
+### Rules
+
+1. **No shared mutable state** — each test creates its own data and cleans up
+2. **No test ordering dependencies** — every test must run independently
+3. **Unique test data** — append timestamps or UUIDs to avoid collisions
+4. **StorageState for auth** — login once in setup project, reuse via `storageState`
+5. **No global variables** — use fixtures for shared context
+
+### Auth Setup Pattern
+
+```typescript
+// tests/commons/login.setup.ts
+import { test as setup } from "@playwright/test";
+
+setup("authenticate", async ({ page }) => {
+  await page.goto(loginUrl);
+  await page.getByLabel("Username").fill(credentials.username);
+  await page.getByLabel("Password").fill(credentials.password);
+  await page.getByRole("button", { name: "Login" }).click();
+  await page.waitForURL("**/home");
+  await page.context().storageState({ path: ".auth/login.json" });
+});
+```
+
+```typescript
+// playwright.config.ts
+projects: [
+  { name: "setup", testMatch: "**/login.setup.ts" },
+  {
+    name: "chromium",
+    dependencies: ["setup"],
+    use: { storageState: ".auth/login.json" },
+  },
+]
+```
+
+### Global Setup (clean auth state)
+
+```typescript
+// global-setup.ts
+import { rm } from "fs/promises";
+
+export default async function globalSetup() {
+  await rm(".auth", { recursive: true, force: true });
+}
+```
+
+---
+
+## Flakiness Prevention
+
+| Cause | Fix |
+|---|---|
+| Element not yet visible | Use `await expect(el).toBeVisible()` before interaction |
+| Async data loading | Use `waitForLoaderToFinish()` or `waitForWebSocketIdle()` |
+| Animation in progress | Wait for animation end or stable state |
+| Stale element reference | Playwright locators are lazy — re-evaluate automatically |
+| Race condition in test data | Use unique data per test run |
+| Network latency | Use `waitForLoadState("networkidle")` sparingly |
+| Clock-dependent tests | Mock time with `page.clock` API |

--- a/skills/qa-automation/reference/locator-strategy.md
+++ b/skills/qa-automation/reference/locator-strategy.md
@@ -1,0 +1,217 @@
+# Locator Strategy — Accessibility-First
+
+## Locator Priority Hierarchy
+
+Always prefer the highest available method. Fall back only when necessary.
+
+| Priority | Method | When to use | Example |
+|---|---|---|---|
+| 1 (best) | `getByRole()` | Buttons, links, headings, checkboxes, textboxes | `page.getByRole("button", { name: "Submit" })` |
+| 2 | `getByLabel()` | Form inputs with visible labels | `page.getByLabel("Email")` |
+| 3 | `getByText()` | Static text content, menu items | `page.getByText("Welcome", { exact: true })` |
+| 4 | `getByPlaceholder()` | Inputs with placeholder text (no label) | `page.getByPlaceholder("Search...")` |
+| 5 | `getByTestId()` | Elements with `data-testid` attribute | `page.getByTestId("submit-btn")` |
+| 6 | CSS selector | Custom components, complex structures | `page.locator(".custom-widget .inner")` |
+| 7 (last) | XPath | Legacy DOM, no other option | Avoid if at all possible |
+
+**Rule**: If you find yourself writing a CSS selector, first check if the element has a role, label, or text content you can use instead.
+
+---
+
+## Locator Patterns in POM
+
+### Simple Locators as Getters
+
+For elements that don't need parameters:
+
+```typescript
+get submitButton() {
+  return this.page.getByRole("button", { name: "Valider" });
+}
+
+get pageTitle() {
+  return this.page.getByRole("heading", { level: 1 });
+}
+
+get searchInput() {
+  return this.page.getByPlaceholder("Rechercher");
+}
+```
+
+### Parameterized Locators as Methods
+
+For elements that vary by label, text, or index:
+
+```typescript
+inputByLabel(label: string) {
+  return this.page.getByLabel(label);
+}
+
+menuItem(name: string) {
+  return this.page.getByRole("menuitem", { name });
+}
+
+tabByName(name: string) {
+  return this.page.getByRole("tab", { name });
+}
+```
+
+### Composite Locators
+
+When simple role/label selectors don't work, compose locators:
+
+```typescript
+// Input inside a specific section
+inputInSection(sectionLabel: string) {
+  return this.page
+    .locator(".form-section", { has: this.page.getByText(sectionLabel) })
+    .locator("input");
+}
+
+// Button with specific icon (no text)
+addButton(tooltip: string) {
+  return this.page.locator(`button[title="${tooltip}"]`);
+}
+
+// Nth item in a list
+listItem(index: number) {
+  return this.page.getByRole("listitem").nth(index);
+}
+```
+
+### Filtering Locators
+
+```typescript
+// Filter by child content
+rowWithText(text: string) {
+  return this.page.getByRole("row").filter({ hasText: text });
+}
+
+// Filter by child element
+rowWithButton(buttonName: string) {
+  return this.page.getByRole("row").filter({
+    has: this.page.getByRole("button", { name: buttonName })
+  });
+}
+```
+
+---
+
+## Waiting Strategies
+
+### Prefer Auto-Wait (default)
+
+Playwright auto-waits for elements before acting. **Do not add explicit waits unless necessary.**
+
+```typescript
+// GOOD — auto-waits for button to be visible and enabled
+await this.submitButton.click();
+
+// BAD — unnecessary explicit wait
+await this.submitButton.waitFor({ state: "visible" });
+await this.submitButton.click();
+```
+
+### When Explicit Waits ARE Needed
+
+#### After async operations (save, load, navigation):
+```typescript
+await this.headerActionBtn(HeaderAction.VALIDER).click();
+await this.waitForLoaderToFinish(this.internalProgressBar);
+```
+
+#### After navigation with WebSocket data loading:
+```typescript
+await this.navigation.goToSubMenu(entry, subMenu, context);
+await this.waitForWebSocketIdle();
+```
+
+#### Waiting for an element to disappear:
+```typescript
+await this.page.locator(".loading-spinner").waitFor({ state: "hidden" });
+```
+
+#### Waiting for network idle after navigation:
+```typescript
+await this.page.waitForLoadState("networkidle");
+```
+
+### NEVER Use Fixed Timeouts
+
+```typescript
+// NEVER do this — flaky and slow
+await this.page.waitForTimeout(2000);
+
+// INSTEAD — wait for a specific condition
+await this.page.waitForLoadState("networkidle");
+await this.loader.waitFor({ state: "hidden" });
+await expect(this.successMessage).toBeVisible();
+```
+
+**Exception**: `page.waitForTimeout()` is acceptable only in debugging sessions, never in committed code.
+
+---
+
+## Assertion Patterns
+
+### Visibility Assertions
+
+```typescript
+await expect(this.pageTitle).toBeVisible();
+await expect(this.errorBanner).not.toBeVisible();
+await expect(this.submitButton).toBeEnabled();
+await expect(this.submitButton).toBeDisabled();
+```
+
+### Text Content Assertions
+
+```typescript
+await expect(this.pageTitle).toHaveText("Expected Title");
+await expect(this.pageTitle).toContainText("Partial");
+await expect(this.statusBadge).toHaveText(/Active|Enabled/);
+```
+
+### Form Value Assertions
+
+```typescript
+await expect(this.inputByLabel("Name")).toHaveValue("John");
+await expect(this.checkbox).toBeChecked();
+await expect(this.checkbox).not.toBeChecked();
+```
+
+### Count Assertions
+
+```typescript
+await expect(this.page.getByRole("listitem")).toHaveCount(5);
+await expect(this.page.getByRole("row")).toHaveCount(11); // 10 data + 1 header
+```
+
+### URL Assertions
+
+```typescript
+await expect(this.page).toHaveURL(/.*\/dashboard/);
+await expect(this.page).toHaveTitle("Dashboard");
+```
+
+### Soft Assertions (non-blocking)
+
+For checks that should not stop the test:
+
+```typescript
+await expect.soft(this.footer).toContainText("v2.0");
+await expect.soft(this.breadcrumb).toBeVisible();
+// Test continues even if these fail
+```
+
+---
+
+## Locator Anti-Patterns
+
+| Wrong | Correct | Why |
+|---|---|---|
+| `page.locator("#submit")` | `page.getByRole("button", { name: "Submit" })` | IDs are brittle, roles are semantic |
+| `page.locator(".btn-primary")` | `page.getByRole("button", { name: "Save" })` | Class names change, roles don't |
+| `page.locator("div > span:nth-child(3)")` | `page.getByText("Expected text")` | DOM structure changes break deep selectors |
+| `page.locator("input[type='text']")` | `page.getByLabel("Field name")` | Multiple text inputs exist, label is unique |
+| `page.waitForTimeout(3000)` | `await expect(el).toBeVisible()` | Fixed waits are slow and flaky |
+| `page.$(selector)` | `page.locator(selector)` | `$` is deprecated, locator is lazy + auto-waits |

--- a/skills/qa-automation/reference/patterns.md
+++ b/skills/qa-automation/reference/patterns.md
@@ -1,0 +1,201 @@
+# Code Patterns & Examples
+
+## Pattern: Multi-Step Form (Wizard)
+
+For forms with multiple volets/steps navigated via "Suivant"/"Valider" buttons.
+
+**POM (Layer 3)**:
+```typescript
+async fillWizardStep1(entrants: Step1Data): Promise<void> {
+  await this.inputByLabel("Libellé").fill(entrants.label);
+  await this.setToggleByLabel(entrants.isTemplate, "Template");
+  await this.searchAndSelect("Category", entrants.category);
+  await this.headerActionBtn(HeaderAction.SUIVANT).click();
+}
+
+async fillWizardStep2(entrants: Step2Data): Promise<void> {
+  await this.setToggleByLabel(false, "Select all");
+  for (const item of entrants.selections) {
+    await this.searchAndSelect("Items", item);
+  }
+  await this.headerActionBtn(HeaderAction.SUIVANT).click();
+}
+
+async submitWizard(): Promise<void> {
+  await this.headerActionBtn(HeaderAction.VALIDER).click();
+  await this.waitForLoaderToFinish(this.internalProgressBar);
+}
+```
+
+**Steps (Layer 2)**:
+```typescript
+async createItemViaWizard(entrants: ItemEntrants, sortants: ItemSortants): Promise<void> {
+  logger.step(`Creating: "${entrants.step1.label}"`);
+  await this.pageFeature.openCreationForm(sortants.addButtonText);
+  await this.pageFeature.fillWizardStep1(entrants.step1);
+  await this.pageFeature.fillWizardStep2(entrants.step2);
+  await this.pageFeature.submitWizard();
+  await this.pageFeature.verifyItemCreated(sortants);
+  logger.success(`Created: "${entrants.step1.label}"`);
+}
+```
+
+---
+
+## Pattern: Search & Select (Proxy Selector)
+
+For fields with a search input that filters and selects from a dropdown.
+
+```typescript
+// Single value
+async searchAndSelect(section: string, value: string): Promise<void> {
+  const searchInput = this.getSearchInputBySection(section);
+  await searchInput.fill(value);
+  await this.getSearchValue(value).click();
+  await searchInput.clear();
+}
+
+// Multiple values
+async searchAndSelectMultiple(section: string, values: string[]): Promise<void> {
+  for (const value of values) {
+    await this.searchAndSelect(section, value);
+  }
+}
+```
+
+---
+
+## Pattern: Filter Panel Dropdown
+
+```typescript
+async filterBy(filterName: string, value: string): Promise<void> {
+  await this.dropdownArrow(filterName).click();
+  await this.dropdownSearchInput(filterName).fill(value);
+  await this.dropdownOption(filterName, value).click();
+  // Close dropdown overlay
+  await this.page.locator(".extendedPanel").dblclick();
+}
+```
+
+---
+
+## Pattern: Navigation to a Module Feature
+
+**Steps (Layer 2)** — always uses enums discovered from the project's components:
+
+```typescript
+async navigateToFeature(): Promise<void> {
+  await this.navigation.navigateToHome();
+  await this.navigation.goToSubMenu(
+    EntryPoint.MODULE_NAME,       // from ActionBar.ts enum
+    SubMenuItem.FEATURE_NAME,     // from SideBar.ts enum
+    ContextSelection.CONTEXT      // from SideBar.ts enum (optional)
+  );
+}
+```
+
+**Important**: Read the project's `ActionBar.ts` and `SideBar.ts` to discover available `EntryPoint`, `SubMenuItem`, and `ContextSelection` enum values.
+
+---
+
+## Pattern: CRUD with In-Test Cleanup
+
+Always clean up test data in the **same test** to avoid orphan data if subsequent tests fail:
+
+```typescript
+async ({ etapesFeature }) => {
+  // Create
+  await etapesFeature.navigateToFeature();
+  await etapesFeature.createItem(jdd.entrants, jdd.sortants);
+
+  // Verify
+  await etapesFeature.verifyItemDetails(jdd.entrants);
+
+  // Cleanup in same test — NOT in afterEach
+  await etapesFeature.deleteItem(jdd.entrants.identifier);
+}
+```
+
+**Exception**: Use `test.afterEach` only when a test specifically validates deletion behavior.
+
+---
+
+## Pattern: Assert Detail Panel
+
+After creating or selecting an item, verify all expected values are displayed:
+
+```typescript
+async verifyItemDetails(entrants: ItemEntrants, sortants: ItemSortants): Promise<void> {
+  const panel = this.detailsPanel;
+  await expect(panel).toContainText(entrants.label);
+  await expect(panel).toContainText(entrants.category);
+  await expect(panel).toContainText(sortants.statusLabel);
+}
+```
+
+---
+
+## Pattern: Allure/Xray Reporting
+
+### Test Naming & Annotations (mandatory)
+
+```typescript
+test(
+  "XRAY-KEY-NNN TC_PRODUCT_MODULE_Description",
+  {
+    tag: "@XRAY-KEY-NNN",
+    annotation: [
+      { type: "test_key", description: "XRAY-KEY-NNN" },
+      { type: "test_summary", description: "TC_PRODUCT_MODULE_Description" },
+    ],
+  },
+  async ({ etapesFeature }) => { /* ... */ }
+);
+```
+
+### Suite Tags
+
+```typescript
+test.describe("Feature", { tag: ["@regression", "@moduleName"] }, () => {
+  // All tests in this describe inherit the tags
+});
+```
+
+### Tag Conventions
+
+| Tag | Purpose | When to use |
+|---|---|---|
+| `@smoke` | Critical path tests | Login, core navigation, main happy path |
+| `@regression` | Full regression suite | All stable functional tests |
+| `@XRAY-KEY-NNN` | Xray traceability | Every test linked to a test case |
+| `@moduleName` | Module grouping | All tests in a module |
+
+### Logger for Allure Steps
+
+```typescript
+import { logger } from "@utils/Logger";
+
+logger.step("Navigating to feature");     // Creates Allure step
+logger.action("Clicking submit button");  // Sub-action within step
+logger.info("Item count: 5");             // Informational log
+logger.success("Item created");           // Green success marker
+logger.warn("Slow response detected");    // Warning marker
+logger.error("Unexpected state");         // Error marker
+```
+
+---
+
+## Anti-Patterns
+
+| Wrong | Correct | Why |
+|---|---|---|
+| `new PageFeature(page)` in spec | Only in fixture file | Breaks DI pattern, hard to maintain |
+| Locators in steps files | Locators only in POM | Steps should be UI-agnostic |
+| `import { test } from "@playwright/test"` in feature spec | Import from module fixture | Misses fixture injection |
+| Hard-coded strings in spec | Use JDD `sortants` values | Breaks data-driven approach |
+| `page.locator(".btn").click()` in spec | Call `etapes.doAction()` | Violates layer separation |
+| Business logic in spec body | Delegate to steps methods | Specs are orchestration only |
+| `any` for JDD data | Typed interfaces | Catches errors at compile time |
+| `page.waitForTimeout(1000)` | `waitForLoaderToFinish()` or auto-wait | Flaky, wastes time |
+| Cleanup in `afterEach` | Cleanup in same test body | Avoids orphan data on failure |
+| Relative imports `../../../` | Path aliases `@pages/`, `@steps/` | Brittle, hard to refactor |

--- a/skills/qa-automation/reference/test-data.md
+++ b/skills/qa-automation/reference/test-data.md
@@ -1,0 +1,240 @@
+# Test Data (JDD) — Structure & Management
+
+## What is JDD?
+
+**JDD** = Jeux De Données (test data files). They externalize ALL test input and expected output data from test code, making tests data-driven and maintainable.
+
+**Location**: `fixtures/jdd/`
+
+---
+
+## JSON Structure
+
+Every JDD file has three sections:
+
+```json
+{
+  "metadata": {
+    "description": "Functional description of this test data set",
+    "version": "1.0.0",
+    "lastUpdated": "YYYY-MM-DD"
+  },
+  "entrants": {
+    // Inputs — what the test types, selects, toggles in the UI
+  },
+  "sortants": {
+    // Expected outputs — what the test asserts/verifies in the UI
+  }
+}
+```
+
+### `entrants` — Input Data
+
+Everything the test **enters** into the UI: text fields, selections, toggles, dates.
+
+```json
+{
+  "entrants": {
+    "step1": {
+      "label": "Product name",
+      "isActive": true,
+      "category": "Category A",
+      "subCategory": "Sub B"
+    },
+    "step2": {
+      "targets": ["Target 1", "Target 2", "Target 3"]
+    },
+    "step3": {
+      "options": ["Option A", "Option C"],
+      "quantity": 5
+    }
+  }
+}
+```
+
+### `sortants` — Expected Output
+
+Everything the test **verifies**: button labels, form titles, success messages, error texts.
+
+```json
+{
+  "sortants": {
+    "addButtonText": "Add item",
+    "formTitle": "Create new item",
+    "successMessage": "Item created successfully",
+    "errorMessages": {
+      "labelRequired": "The label field is required",
+      "duplicateLabel": "An item with this name already exists"
+    }
+  }
+}
+```
+
+---
+
+## File Naming Convention
+
+```
+[PRODUCT]-[MODULE_CODE]-[NNN].json
+```
+
+| Part | Description | Examples |
+|---|---|---|
+| `PRODUCT` | Product/project prefix | `APP`, `ERP`, `CRM` |
+| `MODULE_CODE` | Short module identifier | `FP` (feature), `NAV` (navigation), `AUTH` (auth) |
+| `NNN` | Sequential number, zero-padded | `001`, `002`, `010` |
+
+**Examples**: `APP-FP-001.json`, `ERP-AUTH-001.json`, `CRM-USERS-003.json`
+
+**Shared data file**: `[PRODUCT]-Commun.json` — credentials, common texts, shared references.
+
+---
+
+## TypeScript Interfaces for JDD
+
+**Always** type your JDD data. Avoid `any`.
+
+### Define interfaces in `src/types/`
+
+```typescript
+// src/types/feature.types.ts
+export interface FeatureStep1Entrants {
+  label: string;
+  isActive: boolean;
+  category: string;
+  subCategory: string;
+}
+
+export interface FeatureStep2Entrants {
+  targets: string[];
+}
+
+export interface FeatureEntrants {
+  step1: FeatureStep1Entrants;
+  step2: FeatureStep2Entrants;
+}
+
+export interface FeatureSortants {
+  addButtonText: string;
+  formTitle: string;
+  successMessage: string;
+  errorMessages: {
+    labelRequired: string;
+    duplicateLabel: string;
+  };
+}
+```
+
+### Use typed parameters in Steps and POM
+
+```typescript
+// Steps — typed parameters instead of any
+async createItem(entrants: FeatureEntrants, sortants: FeatureSortants): Promise<void> {
+  await this.pageFeature.fillStep1(entrants.step1);  // TypeScript validates
+  await this.pageFeature.fillStep2(entrants.step2);
+  await this.pageFeature.verify(sortants);
+}
+
+// POM — typed parameters
+async fillStep1(data: FeatureStep1Entrants): Promise<void> {
+  await this.inputByLabel("Label").fill(data.label);       // TS autocompletes
+  await this.setToggleByLabel(data.isActive, "Active");
+  await this.searchAndSelect("Category", data.category);
+}
+```
+
+### Import JDD in specs
+
+```typescript
+import * as jdd from "../../fixtures/jdd/PRODUCT-MODULE-001.json";
+
+// TypeScript infers types from JSON — jdd.entrants.step1.label is string
+await etapesFeature.createItem(jdd.entrants, jdd.sortants);
+```
+
+**Note**: Enable `resolveJsonModule: true` in `tsconfig.json` for typed JSON imports.
+
+---
+
+## Data Type Mapping
+
+| UI Element | JSON Type | Example |
+|---|---|---|
+| Text input | `string` | `"Product name"` |
+| Toggle/checkbox | `boolean` | `true` |
+| Single-select dropdown | `string` | `"Category A"` |
+| Multi-select | `string[]` | `["A", "B", "C"]` |
+| Numeric input | `number` | `42` |
+| Date picker | `string` (ISO) | `"2026-04-18"` |
+| File upload | `string` (path) | `"fixtures/files/test.pdf"` |
+
+---
+
+## Sortants Naming Conventions
+
+Use prefixes to indicate what kind of expected value it is:
+
+| Prefix | Meaning | Example |
+|---|---|---|
+| `texte*` | Expected text content | `texteFormTitle`, `texteBtnSave` |
+| `message*` | Expected message | `messageErreurRequired`, `messageSucces` |
+| `titre*` | Page/section title | `titrePageAccueil` |
+| `label*` | Field label | `labelBoutonSuivant` |
+| `count*` | Expected count | `countItems` |
+| `url*` | Expected URL pattern | `urlRedirection` |
+
+---
+
+## Shared vs Feature-Specific Data
+
+| File | Content | Used by |
+|---|---|---|
+| `PRODUCT-Commun.json` | Login credentials, common UI texts, shared references | All tests via `CommonSteps` |
+| `PRODUCT-MODULE-NNN.json` | Feature-specific inputs and expected outputs | Specific feature spec |
+
+**Rule**: Never duplicate shared data in feature files. Reference `Commun.json` for credentials, common labels, etc.
+
+---
+
+## Test Data Cleanup Strategies
+
+### Strategy 1: Create + Delete in Same Test (preferred)
+
+```typescript
+async ({ etapesFeature }) => {
+  await etapesFeature.createItem(jdd.entrants, jdd.sortants);
+  await etapesFeature.verifyItem(jdd.entrants);
+  await etapesFeature.deleteItem(jdd.entrants.step1.label);
+}
+```
+
+### Strategy 2: Unique Data per Run
+
+Add a timestamp or UUID suffix to avoid collisions in parallel runs:
+
+```typescript
+const uniqueLabel = `${jdd.entrants.step1.label} ${Date.now()}`;
+```
+
+### Strategy 3: Idempotent Setup
+
+Use Playwright's `test.beforeAll` for shared data that multiple tests read but don't modify:
+
+```typescript
+test.beforeAll(async ({ browser }) => {
+  // Create shared reference data via API if available
+});
+```
+
+---
+
+## Anti-Patterns
+
+| Wrong | Correct | Why |
+|---|---|---|
+| Hard-coded strings in spec | Use JDD `sortants` | Data changes don't require code edits |
+| `entrants: any` in steps | Typed interfaces | Catches errors at compile time |
+| Credentials in feature JDD | Use shared `Commun.json` | Single source of truth for auth |
+| Flat JDD structure | Group by form step/section | Easier to find and maintain data |
+| Same label in all test runs | Add unique suffix | Avoids collisions in parallel execution |
+| Mutable shared test data | Immutable or per-test data | Prevents test interdependence |


### PR DESCRIPTION
Closes #34

## Summary

Adds two new QA-focused agent skills.

## New Skills

### manual-test-designer (v1.0.0)
Generates structured, Xray-compatible manual test cases (CSV) and optional JDD test data (JSON) from user stories, feature descriptions, or acceptance criteria.

Key features:
- Applies test design techniques (Equivalence Partitioning, Boundary Value Analysis, Decision Tables, State Transition)
- Outputs Xray-ready CSV for import
- Generates JDD entrants/sortants JSON files
- Integrates with qa-automation skill for test scaffolding

### qa-automation (v2.0.0)
Expert Playwright/TypeScript test automation skill enforcing a strict 3-layer architecture.

Architecture:
\\\
tests/**/*.spec.ts          ← Layer 1: Specs (orchestration only)
src/utils/fixtures/*.ts     ← Dependency injection
src/steps/**/*.ts           ← Layer 2: Steps (business logic)
src/pages/**/*.ts           ← Layer 3: POM (locators + UI)
fixtures/jdd/*.json         ← Test data (entrants / sortants)
\\\

Key features:
- Enforces separation of concerns across 3 layers
- Typed JDD test data with TypeScript interfaces
- Fixture-based dependency injection

## Overlap Review

No problematic overlaps found (see issue #34 for full analysis). The only adjacency is with playwright-skill, which targets ad-hoc browser scripting — qa-automation targets structured project test suites. Skills are complementary.

## Files Changed

- skills/manual-test-designer/SKILL.md + reference/
- skills/qa-automation/SKILL.md + reference/
- docs/manual-test-designer.md, docs/qa-automation.md
- README.md, docs/README.md (skills table updated)