### PR TITLE
feat(meeting-report): make skill project-agnostic with hexagone-monorepo auto-detection

### DIFF
--- a/docs/meeting-report.md
+++ b/docs/meeting-report.md
@@ -6,7 +6,7 @@ Génération automatique de comptes-rendus de réunion en français à partir d'
 
 Rédiger un compte-rendu de réunion prend du temps : écouter ou relire la transcription, réorganiser les échanges par sujet, extraire les décisions, identifier les actions à mener. Ce skill automatise toute la chaîne à partir du fichier `.vtt` exporté depuis Teams, avec en option le rapport de présence `.csv`.
 
-**Spécifique au projet hexagone-monorepo.** Le compte-rendu est rangé automatiquement dans le bon sous-dossier de `docs/reports/` selon le domaine concerné.
+**Agnostique par défaut, enrichi pour hexagone-monorepo.** Le skill fonctionne sur n'importe quel projet. Quand il détecte le projet **hexagone-monorepo**, il active automatiquement la classification par sous-domaine et le routage vers `docs/reports/<sous-domaine>/`. Sur tout autre projet, il écrit dans un dossier unique (`docs/reports/`, `docs/meetings/`, etc.).
 
 ## Utilisation
 
@@ -20,20 +20,35 @@ transforme cette transcription en rapport /chemin/vers/reunion.vtt
 
 Le skill détecte les fichiers automatiquement grâce à leur extension (`.vtt` = transcription, `.csv` = présence).
 
+## Détection du mode projet
+
+Avant tout traitement, le skill détermine le mode en fonction du projet courant :
+
+- **Mode `hexagone-monorepo`** activé si l'un de ces critères est vrai :
+  - `docs/reports/foundation/` ET `docs/reports/interoperability/` existent
+  - Le remote git mentionne `hexagone-monorepo`
+  - Le `package.json` racine a un `name` contenant `hexagone-monorepo`
+- **Mode générique** dans tous les autres cas.
+
+L'utilisateur peut forcer le mode avec « mode générique » ou « mode hexagone ». Le skill annonce le mode détecté en une phrase avant de produire le compte-rendu.
+
 ## Fonctionnement
 
 ```mermaid
 graph LR
     A[.vtt + .csv optionnel] --> B[Parse transcription]
-    B --> C[Classification domaine]
+    B --> M{Mode}
+    M -- hexagone-monorepo --> C[Classification domaine]
+    M -- générique --> G[Dossier unique]
     C --> D[Rewrite par sujet]
+    G --> D
     D --> E[Extraction actions]
-    E --> F[docs/reports/&lt;domaine&gt;/&lt;fichier&gt;.md]
+    E --> F[Fichier .md]
 ```
 
-## Domaines supportés
+## Mode hexagone-monorepo
 
-Le skill classe automatiquement le compte-rendu dans le bon sous-dossier de `docs/reports/` :
+En mode hexagone-monorepo, le skill classe automatiquement le compte-rendu dans le bon sous-dossier de `docs/reports/` :
 
 | Dossier | Contenu |
 |---|---|
@@ -51,16 +66,30 @@ Si la réunion couvre plusieurs domaines, le skill choisit le domaine **dominant
 
 **Cas particulier interop vs GAP.** Les messages HL7 véhiculent des données patient (PID, PV1, NK1…), donc les mots-clés GAP apparaissent naturellement dans une réunion d'interop. Quand des signaux HL7/interop sont présents, le skill classe en `interoperability/` — même si « patient » ou « admission » reviennent souvent — car la réunion parle d'**intégration technique**, pas de workflow métier.
 
+## Mode générique
+
+Aucune classification de domaine. Le skill écrit dans le premier dossier qui existe parmi :
+
+1. `docs/reports/`
+2. `docs/meetings/`
+3. `meetings/`
+4. `reports/`
+
+Si aucun n'existe, il crée `docs/reports/` et l'utilise.
+
 ## Convention de nommage
 
-- **Réunions Foundation** : `YYYY-MM-DD.md` (date seule — une réunion d'équipe par jour au maximum)
-- **Autres domaines** : `YYYY-MM-DD-<slug>.md` (slug généré à partir du sujet détecté)
+| Mode | Cas | Format |
+|---|---|---|
+| hexagone-monorepo | Réunions Foundation | `YYYY-MM-DD.md` (date seule) |
+| hexagone-monorepo | Autres domaines | `YYYY-MM-DD-<slug>.md` |
+| générique | Tous | `YYYY-MM-DD-<slug>.md` |
 
 Le nom de fichier utilise toujours le format ISO `YYYY-MM-DD`, tandis que la date dans le corps du compte-rendu est au format français `DD/MM/YYYY`.
 
 ## Format du compte-rendu
 
-Le compte-rendu respecte exactement la structure existante des rapports hexagone-monorepo :
+Le compte-rendu suit la même structure dans les deux modes :
 
 - **Titre** : `# Compte-rendu — <Type> <Sujet>`
 - **Métadonnées** : date (`DD/MM/YYYY`), organisateur identifié
@@ -93,13 +122,13 @@ Le skill n'invente jamais de noms.
 
 ## Comportement
 
-- Écrit le fichier directement dans `docs/reports/<domaine>/<fichier>.md`
+- Écrit le fichier directement à l'emplacement résolu selon le mode
 - **Ne commite pas** et ne pousse pas — la revue et le commit restent manuels
 - **N'écrase jamais** un compte-rendu existant ; si un fichier avec le même nom existe déjà, un suffixe numérique (`-2`, `-3`) est ajouté
 - **Pas de censure** — les réunions sont considérées comme internes et sûres, les noms et contenus sont conservés tels quels
 
 ## Prérequis
 
-- Être dans le projet **hexagone-monorepo** (le skill suppose que `docs/reports/<domaine>/` existe pour les six domaines)
 - Avoir exporté la transcription `.vtt` depuis Teams
 - Optionnel : avoir exporté le rapport de présence `.csv` pour enrichir la section Participants
+- Mode hexagone-monorepo : le skill suppose que `docs/reports/<domaine>/` existe pour les sous-dossiers concernés (et les crée au besoin si manquants)

--- a/skills/meeting-report/SKILL.md
+++ b/skills/meeting-report/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: meeting-report
-description: "Génère automatiquement un compte-rendu de réunion en français à partir d'une transcription Teams (.vtt) et optionnellement d'un rapport de présence (.csv). Spécifique au projet hexagone-monorepo. À utiliser quand l'utilisateur dépose un ou deux chemins de fichiers Teams dans le prompt et demande la génération d'un compte-rendu."
+description: "Génère automatiquement un compte-rendu de réunion en français à partir d'une transcription Teams (.vtt) et optionnellement d'un rapport de présence (.csv). Agnostique par défaut, avec un mode enrichi auto-détecté pour le projet hexagone-monorepo. À utiliser quand l'utilisateur dépose un ou deux chemins de fichiers Teams dans le prompt et demande la génération d'un compte-rendu."
 allowed-tools: Read, Write, Bash, Grep, Glob
-version: 1.1.0
+version: 1.2.0
 license: MIT
 metadata:
   author: Foundation Skills
@@ -10,9 +10,9 @@ metadata:
 
 # Meeting Report
 
-Generate a structured French meeting report from a Microsoft Teams `.vtt` transcript, optionally enriched with a Teams `.csv` attendance report. The report is written to the correct sub-domain folder under `docs/reports/` inside the **hexagone-monorepo** project.
+Generate a structured French meeting report from a Microsoft Teams `.vtt` transcript, optionally enriched with a Teams `.csv` attendance report.
 
-**This skill is specific to the hexagone-monorepo project.** It assumes the working directory is hexagone-monorepo and that `docs/reports/` exists with the following sub-domain folders: `foundation/`, `core/`, `interoperability/`, `gap/`, `grh/`, `gef/`, `ui-ux/`.
+The skill works on **any project**. It auto-detects the **hexagone-monorepo** project and, when detected, applies project-specific rules (sub-domain classification, sub-folder routing, foundation date-only naming). On any other project, it falls back to a generic single-folder output.
 
 ## When to Use This Skill
 
@@ -31,6 +31,24 @@ The skill expects **one or two file paths** dropped in the user prompt:
 - **Optional:** `.csv` file — Teams attendance report
 
 Detection: inspect file extensions in the user prompt. If both are present, `.vtt` is the transcript and `.csv` is the attendance report. If only one file is dropped, it must be the `.vtt`.
+
+## Project Mode Detection
+
+Before processing, decide whether the current working directory is the **hexagone-monorepo** project. This sets the routing behavior for the rest of the workflow.
+
+Run these checks (any one of them is sufficient to enter `hexagone-monorepo` mode):
+
+1. **Folder layout** — `docs/reports/foundation/` AND `docs/reports/interoperability/` both exist
+2. **Git remote** — `git remote -v` mentions `hexagone-monorepo`
+3. **Package name** — root `package.json` has a `name` containing `hexagone-monorepo`
+
+If none match → **generic mode**.
+
+The user may also explicitly override:
+- « mode générique » / « generic mode » → force generic
+- « mode hexagone » → force hexagone-monorepo (only valid if the layout exists)
+
+State the detected mode in one short sentence to the user before producing the report (e.g. « Mode détecté : hexagone-monorepo. » or « Mode détecté : générique. »).
 
 ## Workflow
 
@@ -78,9 +96,11 @@ Priority order:
 
    > « La transcription est anonyme et aucun fichier de présence n'est fourni. Peux-tu me donner la liste des participants ? »
 
-### Step 4: Classify the Sub-Domain
+### Step 4: Classify the Sub-Domain (hexagone-monorepo mode only)
 
-Analyze transcript content for domain signals using the table below (case-insensitive keyword matching):
+**Skip this step in generic mode.** In generic mode, there is no domain classification — the report goes to a single output folder (see Step 11).
+
+In **hexagone-monorepo mode**, analyze transcript content for domain signals using the table below (case-insensitive keyword matching):
 
 | Folder | Signals (French / technical keywords) |
 |---|---|
@@ -167,7 +187,7 @@ Place the diagram **inside the relevant topic section**, not at the top of the r
 
 ### Step 9: Assemble the Report
 
-Use this exact template (matches the hexagone-monorepo existing convention):
+Use this exact template:
 
 ```markdown
 # Compte-rendu — <Type de réunion> <Sujet>
@@ -225,64 +245,103 @@ Use this exact template (matches the hexagone-monorepo existing convention):
 
 ### Step 10: Determine the Filename
 
-Rule:
+**hexagone-monorepo mode:**
+- Foundation team meetings (`foundation/` folder) → `YYYY-MM-DD.md` (date only, no slug — one standing team meeting per day maximum)
+- All other folders → `YYYY-MM-DD-<slug>.md`
 
-- **Foundation team meetings** (`foundation/` folder) → `YYYY-MM-DD.md` (date only, no slug — one standing team meeting per day maximum)
-- **All other folders** → `YYYY-MM-DD-<slug>.md`
+**Generic mode:**
+- Always `YYYY-MM-DD-<slug>.md`
 
 The filename always uses the **ISO date format** `YYYY-MM-DD`, different from the French `DD/MM/YYYY` used in the report body.
 
-### Step 11: Write the File
+### Step 11: Resolve the Output Folder and Write the File
 
-1. Build the target path: `docs/reports/<folder>/<filename>.md`
-2. Verify the target folder exists using Bash (`ls docs/reports/<folder>/`)
-3. Check if a file with the same name already exists — if yes, append `-2`, `-3`, etc. before writing (do NOT overwrite)
-4. Write the file with the Write tool
+**hexagone-monorepo mode:**
+1. Target path: `docs/reports/<sub-domain>/<filename>.md`
+2. Verify the sub-domain folder exists (`ls docs/reports/<sub-domain>/`). If missing, create it.
+
+**Generic mode:**
+1. Pick the first existing folder among:
+   - `docs/reports/`
+   - `docs/meetings/`
+   - `meetings/`
+   - `reports/`
+2. If none exists, create `docs/reports/` and use it.
+3. Target path: `<chosen-folder>/<filename>.md`
+
+**Common to both modes:**
+1. Check if a file with the same name already exists — if yes, append `-2`, `-3`, etc. before writing (do NOT overwrite)
+2. Write the file with the Write tool
 
 ### Step 12: Report to the User
 
 Show a concise summary:
 
-1. ✓ Target path: `docs/reports/<folder>/<filename>.md`
-2. One-line summary: domain detected, number of topics, number of actions, number of participants
-3. Note any fallback that was triggered (no attendance CSV, no voice tags, today's date used because no date found, etc.)
-4. **Stop.** Do not run `git add`, `git commit`, or `git push`. The user commits the file manually after review.
+1. ✓ Mode: `hexagone-monorepo` or `generic`
+2. ✓ Target path
+3. One-line summary: (sub-domain in hexagone mode), number of topics, number of actions, number of participants
+4. Note any fallback that was triggered (no attendance CSV, no voice tags, today's date used because no date found, default folder created, etc.)
+5. **Stop.** Do not run `git add`, `git commit`, or `git push`. The user commits the file manually after review.
 
 ## Important Notes
 
-- **This skill is specific to the hexagone-monorepo project.** It assumes the current working directory is hexagone-monorepo and that `docs/reports/<sub-domain>/` exists for the six domains.
-- **No redaction or pseudonymization.** Team meetings are considered internal and trusted. Patient names, client hospitals, commercial info, and personnel names may appear verbatim in reports.
+- **Project-agnostic by default.** Sub-domain classification and `docs/reports/<sub-domain>/` routing only apply when the hexagone-monorepo project is detected.
+- **No redaction or pseudonymization.** Team meetings are considered internal and trusted. Names and content may appear verbatim in reports.
 - **No git actions.** The skill writes the file and stops. Commit and push are manual.
 - **Rewrite heavily — do not transcribe.** The output is a thematic synthesis, not chronological minutes.
 - **Fix French accents aggressively.** Teams `.vtt` French transcripts routinely miss accents and punctuation.
-- **Foundation meetings use date-only naming.** All other folders use `YYYY-MM-DD-<slug>.md`.
+- **Foundation date-only naming applies only in hexagone-monorepo mode.** Generic mode always uses `YYYY-MM-DD-<slug>.md`.
 - **Mermaid is optional, rare, and only when useful.** Default is no diagram.
 - **Participants fallback order:** `.csv` first, then `<v>` voice tags, then ask the user. Never invent names.
 - **Never overwrite an existing report.** Append a numeric suffix if a file with the same name already exists.
 
 ## Examples
 
-### Example 1: UX/UI atelier with attendance CSV
+### Example 1: Generic project, simple meeting
+
+```
+User: crée un compte-rendu de cette transcription Teams /tmp/kickoff.vtt
+
+→ Detection: no docs/reports/foundation/ found → generic mode
+→ Skill reads the .vtt
+→ Parses <v> voice tags → 5 speakers
+→ Extracts date 2026-04-22
+→ Picks docs/reports/ (exists) as output folder
+→ Writes docs/reports/2026-04-22-kickoff-projet.md
+→ Reports: « Mode détecté : générique. »
+```
+
+### Example 2: Generic project, no docs/reports folder yet
+
+```
+User: génère le compte-rendu /tmp/atelier.vtt /tmp/attendees.csv
+
+→ Detection: generic mode
+→ No docs/reports/, no docs/meetings/, no meetings/, no reports/ → creates docs/reports/
+→ Writes docs/reports/2026-04-15-atelier-architecture.md
+→ Reports: « Mode détecté : générique. Dossier docs/reports/ créé. »
+```
+
+### Example 3 (hexagone-monorepo): UX/UI atelier with attendance CSV
 
 ```
 User: crée un compte-rendu de cette transcription Teams /tmp/atelier_recherche_patient.vtt /tmp/attendees.csv
 
+→ Detection: docs/reports/foundation/ + interoperability/ exist → hexagone-monorepo mode
 → Skill reads both files
 → Extracts date from .vtt NOTE header: 2026-03-18
 → Participants from .csv: Chloé Julenon, Richard Gill, Adrien Marcos, Myriam Fatoux, Damien Battistella
 → Detects ui-ux signals (atelier, écran, maquette, recherche patient)
 → Classifies as ui-ux/
-→ Extracts topics, decisions, actions
 → Writes docs/reports/ui-ux/2026-03-18-atelier-recherche-patient.md
-→ Reports path to user
 ```
 
-### Example 2: Foundation team sprint review, no CSV
+### Example 4 (hexagone-monorepo): Foundation team sprint review, no CSV
 
 ```
 User: génère le compte-rendu de cette réunion /tmp/sprint_review.vtt
 
-→ Skill reads the .vtt
+→ Detection: hexagone-monorepo mode
 → Parses <v Speaker> voice tags → extracts 4 speakers
 → Extracts date from NOTE header: 2026-04-10
 → Detects foundation signals (sprint, rétro, point équipe)
@@ -291,36 +350,23 @@ User: génère le compte-rendu de cette réunion /tmp/sprint_review.vtt
 → Writes docs/reports/foundation/2026-04-10.md
 ```
 
-### Example 3: Anonymous transcript with no CSV
+### Example 5: Anonymous transcript with no CSV (any mode)
 
 ```
 User: transforme cette transcription en rapport /tmp/meeting.vtt
 
-→ Skill reads the .vtt
 → No <v> tags found
 → No .csv provided
 → Stops and asks: « La transcription est anonyme et aucun fichier de présence n'est fourni. Peux-tu me donner la liste des participants ? »
 → Waits for the user, then continues with the provided names
 ```
 
-### Example 4: Multi-domain transcript
-
-```
-User: compte-rendu /tmp/point_facturation_ght.vtt
-
-→ Skill reads the .vtt
-→ Detects signals for both gap (facturation, venue, séjour) and gef (HA GHT, pharmacie mentioned in passing)
-→ gap has significantly more keyword hits → picks gap as dominant
-→ Classifies as gap/
-→ Writes docs/reports/gap/2026-04-08-point-facturation-ght.md
-```
-
-### Example 5: Hexaflux weekly — HL7 discussion, not GAP
+### Example 6 (hexagone-monorepo): Hexaflux weekly — HL7 discussion, not GAP
 
 ```
 User: crée un compte-rendu /tmp/hexaflux_weekly.vtt
 
-→ Skill reads the .vtt
+→ Detection: hexagone-monorepo mode
 → Detects HL7 / ADT / PID / PV1 / NK1 / OBX / segment / mapping signals
 → Patient and admission keywords are present BUT tied to HL7 message segments, not business workflows
 → Applies the interop-vs-gap disambiguation rule → picks interoperability/


### PR DESCRIPTION
## Summary

- Make `meeting-report` work on any project by default; auto-detect `hexagone-monorepo` to preserve existing sub-domain classification and routing
- Detection looks at `docs/reports/foundation|interoperability/` layout, git remote, or root `package.json` name; user can override with « mode générique » / « mode hexagone »
- Generic mode skips domain classification, picks the first existing output folder among `docs/reports/`, `docs/meetings/`, `meetings/`, `reports/` (creates `docs/reports/` if none), and always names files `YYYY-MM-DD-<slug>.md` (Foundation date-only naming stays hexagone-only)
- Bump skill `version` to 1.2.0; update `docs/meeting-report.md` to document both modes

## Test plan

- [ ] Run on hexagone-monorepo: same routing/filenames as before (no regression in `foundation/`, `interoperability/`, `gap/`, etc.)
- [ ] Run on a non-hexagone project with existing `docs/reports/` → file lands there with `YYYY-MM-DD-<slug>.md`
- [ ] Run on a non-hexagone project with no candidate folder → `docs/reports/` is created and used
- [ ] Override « mode générique » on hexagone-monorepo writes to the generic folder